### PR TITLE
sensors.conf.default: Add hardwired NCT6796D inputs

### DIFF
--- a/etc/sensors.conf.default
+++ b/etc/sensors.conf.default
@@ -311,7 +311,8 @@ chip "w83627thf-*"
 #    set in8_max  3.0 * 1.10
 
 
-chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" "nct6779-*" "nct6791-*" "nct6795-*"
+chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" \
+     "nct6779-*" "nct6791-*" "nct6795-*" "nct6796-*"
 
     label in0 "Vcore"
     label in2 "AVCC"


### PR DESCRIPTION
It seems Nuvoton NCT6796D also has the same hardwired inputs.

This was determined experimentally on an ASUS PRIME B360M-A board.

Signed-off-by: Roy Zhang <pudh4418@gmail.com>