### PR TITLE
Exit with 1 on error. Don't print a newline when ignore was used. Skip empty line and omit the comma

### DIFF
--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -110,6 +110,7 @@ void print_chip_json(const sensors_chip_name *name)
 
 			} else {
 				printf("(%s)", label);
+				subCnt++;
 			}
 		}
 		free(label);

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -112,7 +112,9 @@ void print_chip_json(const sensors_chip_name *name)
 		printf("\n      }");
 		cnt++;
 	}
-	printf("\n");
+  if (0 != cnt) {
+    printf("\n");
+  }
 }
 
 static const char hyst_str[] = "hyst";

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -116,9 +116,9 @@ void print_chip_json(const sensors_chip_name *name)
 		printf("\n      }");
 		cnt++;
 	}
-  if (0 != cnt) {
-    printf("\n");
-  }
+        if (0 != cnt) {
+                printf("\n");
+        }
 }
 
 static const char hyst_str[] = "hyst";

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -45,6 +45,7 @@ void print_chip_raw(const sensors_chip_name *name)
 		if (!(label = sensors_get_label(name, feature))) {
 			fprintf(stderr, "ERROR: Can't get label of feature "
 				"%s!\n", feature->name);
+			err_code = 1;
 			continue;
 		}
 		printf("%s:\n", label);
@@ -53,12 +54,13 @@ void print_chip_raw(const sensors_chip_name *name)
 		while ((sub = sensors_get_all_subfeatures(name, feature, &b))) {
 			if (sub->flags & SENSORS_MODE_R) {
 				if ((err = sensors_get_value(name, sub->number,
-							     &val)))
+							     &val))) {
 					fprintf(stderr, "ERROR: Can't get "
 						"value of subfeature %s: %s\n",
 						sub->name,
 						sensors_strerror(err));
-				else
+					err_code = 1;
+        } else
 					printf("  %s: %.3f\n", sub->name, val);
 			} else
 				printf("(%s)\n", label);
@@ -81,6 +83,7 @@ void print_chip_json(const sensors_chip_name *name)
 		if (!(label = sensors_get_label(name, feature))) {
 			fprintf(stderr, "ERROR: Can't get label of feature "
 				"%s!\n", feature->name);
+			err_code = 1;
 			continue;
 		}
 		if (cnt > 0)
@@ -97,6 +100,7 @@ void print_chip_json(const sensors_chip_name *name)
 						"value of subfeature %s: %s\n",
 						sub->name,
 						sensors_strerror(err));
+					err_code = 1;
 				} else {
 					if (subCnt > 0)
 						printf(",\n");
@@ -140,6 +144,7 @@ static double get_value(const sensors_chip_name *name,
 	if (err) {
 		fprintf(stderr, "ERROR: Can't get value of subfeature %s: %s\n",
 			sub->name, sensors_strerror(err));
+		err_code = 1;
 		val = 0;
 	}
 	return val;
@@ -156,6 +161,7 @@ static int get_input_value(const sensors_chip_name *name,
 	if (err && err != -SENSORS_ERR_ACCESS_R) {
 		fprintf(stderr, "ERROR: Can't get value of subfeature %s: %s\n",
 			sub->name, sensors_strerror(err));
+		err_code = 1;
 	}
 	return err;
 }
@@ -353,6 +359,7 @@ static void print_chip_temp(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);
@@ -441,6 +448,7 @@ static void print_chip_in(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);
@@ -474,6 +482,7 @@ static void print_chip_fan(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);
@@ -617,6 +626,7 @@ static void print_chip_power(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);
@@ -684,6 +694,7 @@ static void print_chip_energy(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);
@@ -796,6 +807,7 @@ static void print_chip_curr(const sensors_chip_name *name,
 	if (!(label = sensors_get_label(name, feature))) {
 		fprintf(stderr, "ERROR: Can't get label of feature %s!\n",
 			feature->name);
+		err_code = 1;
 		return;
 	}
 	print_label(label, label_size);

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -116,9 +116,9 @@ void print_chip_json(const sensors_chip_name *name)
 		printf("\n      }");
 		cnt++;
 	}
-        if (0 != cnt) {
-                printf("\n");
-        }
+	if (0 != cnt) {
+		printf("\n");
+	}
 }
 
 static const char hyst_str[] = "hyst";

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -105,12 +105,12 @@ void print_chip_json(const sensors_chip_name *name)
 					if (subCnt > 0)
 						printf(",\n");
 					printf("         \"%s\": %.3f", sub->name, val);
+					subCnt++;
 				}
 
 			} else {
 				printf("(%s)", label);
 			}
-			subCnt++;
 		}
 		free(label);
 		printf("\n      }");

--- a/prog/sensors/main.c
+++ b/prog/sensors/main.c
@@ -168,7 +168,7 @@ static void do_a_print(const sensors_chip_name *name)
 		else {
 			fprintf(stderr, "Can't get adapter name\n");
 			err_code = 1;
-                }
+		}
 	}
 	if (do_raw)
 		print_chip_raw(name);
@@ -187,7 +187,7 @@ static void do_a_json_print(const sensors_chip_name *name)
 		else {
 			fprintf(stderr, "Can't get adapter name\n");
 			err_code = 1;
-                }
+		}
 	}
 	print_chip_json(name);
 	printf("   }");

--- a/prog/sensors/main.c
+++ b/prog/sensors/main.c
@@ -168,7 +168,7 @@ static void do_a_print(const sensors_chip_name *name)
 		else {
 			fprintf(stderr, "Can't get adapter name\n");
 			err_code = 1;
-    }
+                }
 	}
 	if (do_raw)
 		print_chip_raw(name);
@@ -187,7 +187,7 @@ static void do_a_json_print(const sensors_chip_name *name)
 		else {
 			fprintf(stderr, "Can't get adapter name\n");
 			err_code = 1;
-    }
+                }
 	}
 	print_chip_json(name);
 	printf("   }");

--- a/prog/sensors/main.h
+++ b/prog/sensors/main.h
@@ -23,5 +23,6 @@
 
 extern int fahrenheit;
 extern char degstr[5];
+extern int err_code;
 
 #endif /* PROG_SENSORS_MAIN_H */


### PR DESCRIPTION
By default the program exits with 1 on several occasions, but doesn't exit with -1 on error. This is out to resolve @lasers wish in #121 