### PR TITLE
sensord: add oneline sensor log output option

### DIFF
--- a/prog/sensord/args.c
+++ b/prog/sensord/args.c
@@ -93,6 +93,7 @@ static const char *daemonSyntax =
 	"  -i, --interval <time>     -- interval between scanning alarms (default 60s)\n"
 	"  -l, --log-interval <time> -- interval between logging sensors (default 30m)\n"
 	"  -t, --rrd-interval <time> -- interval between updating RRD file (default 5m)\n"
+	"  -1, --oneline             -- log chip, adapter, and sensor data on one line\n"
 	"  -T, --rrd-no-average      -- switch RRD in non-average mode\n"
 	"  -r, --rrd-file <file>     -- RRD file (default <none>)\n"
 	"  -c, --config-file <file>  -- configuration file\n"
@@ -116,12 +117,13 @@ static const char *daemonSyntax =
 	"the RRD file configuration must EXACTLY match the sensors that are used. If\n"
 	"your configuration changes, delete the old RRD file and restart sensord.\n";
 
-static const char *shortOptions = "i:l:t:Tf:r:c:p:advhg:";
+static const char *shortOptions = "i:l:t:1Tf:r:c:p:advhg:";
 
 static const struct option longOptions[] = {
 	{ "interval", required_argument, NULL, 'i' },
 	{ "log-interval", required_argument, NULL, 'l' },
 	{ "rrd-interval", required_argument, NULL, 't' },
+	{ "oneline", no_argument, NULL, '1' },
 	{ "rrd-no-average", no_argument, NULL, 'T' },
 	{ "syslog-facility", required_argument, NULL, 'f' },
 	{ "rrd-file", required_argument, NULL, 'r' },
@@ -160,6 +162,9 @@ int parseArgs(int argc, char **argv)
 		case 't':
 			if ((sensord_args.rrdTime = parseTime(optarg)) < 0)
 				return -1;
+			break;
+		case '1':
+			sensord_args.logOneline = 1;
 			break;
 		case 'T':
 			sensord_args.rrdNoAverage = 1;

--- a/prog/sensord/args.h
+++ b/prog/sensord/args.h
@@ -13,6 +13,7 @@ struct sensord_arguments {
 	const char *cgiDir;
 	int scanTime;
 	int logTime;
+	int logOneline;
 	int rrdTime;
 	int rrdNoAverage;
 	int syslogFacility;

--- a/prog/sensord/sense.c
+++ b/prog/sensord/sense.c
@@ -53,13 +53,15 @@ static int idChip(const sensors_chip_name *chip)
 		return -1;
 	}
 
-	sensorLog(LOG_INFO, "Chip: %s", name);
+	if (!sensord_args.logOneline)
+		sensorLog(LOG_INFO, "Chip: %s", name);
 
 	adapter = sensors_get_adapter_name(&chip->bus);
 	if (!adapter)
 		sensorLog(LOG_INFO, "Error getting adapter name");
 	else
-		sensorLog(LOG_INFO, "Adapter: %s", adapter);
+		if (!sensord_args.logOneline)
+			sensorLog(LOG_INFO, "Adapter: %s", adapter);
 
 	return 0;
 }
@@ -142,9 +144,15 @@ static int do_features(const sensors_chip_name *chip,
 		return -1;
 	}
 
-	if (action == DO_READ)
-		sensorLog(LOG_INFO, "  %s: %s", label, formatted);
-	else
+	if (action == DO_READ) {
+		if (sensord_args.logOneline)
+			sensorLog(LOG_INFO, "Chip: %s Adapter: %s  %s: %s",
+				  chipName(chip),
+				  sensors_get_adapter_name(&chip->bus),
+				  label, formatted);
+		else
+			sensorLog(LOG_INFO, "  %s: %s", label, formatted);
+	} else
 		sensorLog(LOG_ALERT, "Sensor alarm: Chip %s: %s: %s",
 			  chipName(chip), label, formatted);
 

--- a/prog/sensord/sensord.8
+++ b/prog/sensord/sensord.8
@@ -58,6 +58,8 @@ The time is specified as before; e.g., `30m'.
 
 Specify an interval of zero to suppress logging of regular sensor
 readings.
+.IP "-1, --oneline"
+Log sensor value, chip, and adapter on one line for easier parsing.
 .IP "-t, --rrd-interval time"
 Specify the interval between logging all sensor readings to a round-robin
 database; the default is to log all readings every five minutes


### PR DESCRIPTION
Add an option `-1`/`--oneline` that logs the updates sensor value with the chip and adapter on the same line.

This makes it easier to parse and uniquely identify sensors without labels, such as `temp1` in the example below.

Without `--oneline`:

```
Chip: iwlwifi-virtual-0
Adapter: Virtual device
  temp1: 35.0 C
Chip: coretemp-isa-0000
Adapter: ISA adapter
  Package id 0: 46.0 C
  Core 0: 43.0 C
  Core 1: 43.0 C
  Core 2: 39.0 C
  Core 3: 41.0 C
Chip: acpitz-virtual-0
Adapter: Virtual device
  temp1: 25.0 C
Chip: dell_smm-virtual-0
Adapter: Virtual device
  Processor Fan: 2512 RPM
  Video Fan: 2498 RPM
  CPU: 46.0 C
  Ambient: 54.0 C
  Ambient: 47.0 C
  Other: 40.0 C
Chip: pch_skylake-virtual-0
Adapter: Virtual device
  temp1: 66.0 C
```

With `--oneline`:

```
Chip: iwlwifi-virtual-0 Adapter: Virtual device  temp1: 34.0 C
Chip: coretemp-isa-0000 Adapter: ISA adapter  Package id 0: 47.0 C
Chip: coretemp-isa-0000 Adapter: ISA adapter  Core 0: 42.0 C
Chip: coretemp-isa-0000 Adapter: ISA adapter  Core 1: 43.0 C
Chip: coretemp-isa-0000 Adapter: ISA adapter  Core 2: 39.0 C
Chip: coretemp-isa-0000 Adapter: ISA adapter  Core 3: 41.0 C
Chip: acpitz-virtual-0 Adapter: Virtual device  temp1: 25.0 C
Chip: dell_smm-virtual-0 Adapter: Virtual device  Processor Fan: 2512 RPM
Chip: dell_smm-virtual-0 Adapter: Virtual device  Video Fan: 2501 RPM
Chip: dell_smm-virtual-0 Adapter: Virtual device  CPU: 46.0 C
Chip: dell_smm-virtual-0 Adapter: Virtual device  Ambient: 54.0 C
Chip: dell_smm-virtual-0 Adapter: Virtual device  Ambient: 48.0 C
Chip: dell_smm-virtual-0 Adapter: Virtual device  Other: 40.0 C
Chip: pch_skylake-virtual-0 Adapter: Virtual device  temp1: 66.0 C
```

Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>