### PR TITLE
sensord: check for syslog socket

### DIFF
--- a/prog/sensord/sensord.c
+++ b/prog/sensord/sensord.c
@@ -142,6 +142,27 @@ static int sensord(void)
 
 static void openLog(void)
 {
+	struct stat fileStat;
+	int ret;
+
+	// Linux log
+	ret = stat("/dev/log", &fileStat);
+	if (ret == 0)
+		goto found;
+
+	// BSD log
+	ret = stat("/var/run/log", &fileStat);
+	if (ret == 0)
+		goto found;
+
+	// systemd log
+	ret = stat("/run/systemd/journal/syslog", &fileStat);
+	if (ret == 0)
+		goto found;
+
+	return;
+
+found:
 	openlog("sensord", 0, sensord_args.syslogFacility);
 	logOpened = 1;
 }


### PR DESCRIPTION
syslog `openlog()` doesn't return an error if a log socket does not exist. For example, inside a container or embedded system.

sensord should detect this so that `sensorLog()` logs to `stderr`.

Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>