### PR TITLE
configs: add support for ASUS B350-F (WIP)

### DIFF
--- a/configs/Asus/B350-F-ROG-STRIX.conf
+++ b/configs/Asus/B350-F-ROG-STRIX.conf
@@ -1,0 +1,11 @@
+chip "it8622-isa-0290"
+
+    label fan1 "CPU_FAN"
+    label fan2 "Pump"
+    label fan3 "SYSTEM_FAN1"
+    label fan4 "SYSTEM_FAN2"
+    label fan5 "SYSTEM_FAN3"
+
+    label temp1 "CPU Temp"
+    label temp2 "M/B Temp"
+    label temp3 "Chipset"

--- a/configs/Asus/B350-F-ROG-STRIX.conf
+++ b/configs/Asus/B350-F-ROG-STRIX.conf
@@ -9,3 +9,9 @@ chip "it8622-isa-0290"
     label temp1 "CPU Temp"
     label temp2 "M/B Temp"
     label temp3 "Chipset"
+
+# todo: find out about compute values
+
+#    compute fan3
+#    compute fan4
+#    compute fan5


### PR DESCRIPTION
`CPU_FAN:      835 RPM  (min =   18 RPM)` 
first value correct, min value incorrect
`SYSTEM_FAN1:    0 RPM  (min =   41 RPM)  ALARM`
max RPM = 1450; 20% of that is minimum rpm per bios = 0 RPM should be 290 RPM

how do set that offset for SYSTEM_FAN1 to begin with? `compute fan3` needs a certain value, but I don't really get the logic of these values. Can someone help me out? 