### PR TITLE
add Gigabyte GA-F2A88XM-HD3 and MSI MS-7A34 (B350 TOMAHAWK) config

### DIFF
--- a/configs/Gigabyte/GA-F2A88XM-HD3.conf
+++ b/configs/Gigabyte/GA-F2A88XM-HD3.conf
@@ -1,0 +1,52 @@
+# contributed by Maciej S. Szmigiero <mail@maciej.szmigiero.name>
+#
+# input routing and scaling read from board schematic
+#
+# likely valid also for other boards in GA-F2A88XM-x family
+
+chip "it8620-*"
+	label in0 "CPU Vcore"
+	label in1 "DRAM Voltage"
+
+	label in2 "+12V"
+	compute in2 ((75 / 15) + 1) * @, @ / ((75 / 15) + 1)
+	set in2_min 12 * 0.95
+	set in2_max 12 * 1.05
+
+	label in3 "+5V"
+	compute in3 ((15 / 10) + 1) * @, @ / ((15 / 10) + 1)
+	set in3_min 5 * 0.95
+	set in3_max 5 * 1.05
+
+	label in4 "+3.3V"
+	compute in4 ((649 / 1000) + 1) * @, @ / ((649 / 1000) + 1)
+	set in4_min 3.3 * 0.95
+	set in4_max 3.3 * 1.05
+
+	# likely left unconnected
+	ignore in5
+	ignore in6
+
+	set in7_min 3.3 * 0.95
+	set in7_max 3.3 * 1.05
+
+	label fan1 "CPU Fan"
+	label fan2 "System Fan"
+	ignore fan3
+	ignore fan4
+	ignore fan5
+
+	label temp1 "System Temp"
+
+	# likely left unconnected
+	# no sensor configured for this input in the chip
+	ignore temp2
+
+	# the same (virtual) temperature as reported by k10temp
+	# just offset by 13°C (from temp3_offset) for fan control
+	ignore temp3
+
+	# stuck at 45°C
+	ignore temp4
+	ignore temp5
+	ignore temp6

--- a/configs/MSI/MS-7A34-B350-TOMAHAWK.conf
+++ b/configs/MSI/MS-7A34-B350-TOMAHAWK.conf
@@ -1,0 +1,72 @@
+# contributed by Maciej S. Szmigiero <mail@maciej.szmigiero.name>
+#
+# input routing and scaling based on schematic of a similar
+# MS-7B00 (B350 Gaming Pro Carbon) board
+
+chip "nct6795-*"
+	label in1 "5V"
+	compute in1 ((12 / 3) + 1) * @, @ / ((12 / 3) + 1)
+	set in1_min 5 * 0.95
+	set in1_max 5 * 1.05
+
+	label in4 "12V"
+	compute in4 ((220 / 20) + 1) * @, @ / ((220 / 20) + 1)
+	set in4_min 12 * 0.95
+	set in4_max 12 * 1.05
+
+	# no VIN8 input in this chip?
+	ignore in5
+
+	# likely AUXTIN0 thermistor
+	ignore in6
+
+	label in9 "CPU 1P8"
+
+	# might read as 0V if a CPU without iGPU is installed
+	label in10 "CPU VDDP"
+
+	# likely AUXTIN2 thermistor
+	ignore in11
+
+	label in12 "CPU NB/SOC"
+	# 2:1 agrees with BIOS, but the MS-7B00 schematic is
+	# unclear whether this is scaled 2:1 or 1:1
+	compute in12 2 * @, @ / 2
+
+	label in13 "DRAM"
+	compute in13 2 * @, @ / 2
+
+	label in14 "5VSB"
+	compute in14 ((768 / 330) + 1) * @, @ / ((768 / 330) + 1)
+	set in14_min 5 * 0.95
+	set in14_max 5 * 1.05
+
+	# FIXME: resolve the remaining fan inputs
+	label fan2 "CPU 1"
+	label fan3 "SYSTEM 1"
+
+	# likely
+	label temp3 "CPU MOS"
+
+	# AUXTIN1 is used as VIN5
+	ignore temp4
+
+	# on MS-7B00 this is a thermistor under the B350 chip itself
+	#
+	# seems to work properly only on some boards (at least one
+	# has it stuck at 23°C)
+	label temp5 "B350"
+
+	# AUXTIN3 is used as VIN7
+	ignore temp6
+
+	# the same temperature as reported by k10temp
+	label temp7 "CPU die"
+
+	# stuck at 0°C
+	ignore temp8
+	ignore temp9
+	ignore temp10
+
+	# likely DEEP_S5 signal
+	ignore intrusion1


### PR DESCRIPTION
This pull request adds configs for Gigabyte GA-F2A88XM-HD3 and MSI MS-7A34 (B350 TOMAHAWK)
boards.

Input routings and scalings were read from schematic of either the board itself
(in the GA-F2A88XM-HD3 case) or from a similar board (in the MSI MS-7A34 case),
then confirmed experimentally. 
