### PR TITLE
configs: add support for X470 ultra gaming (WIP)

### DIFF
--- a/configs/Gigabyte/X470-AORUS-ULTRA-GAMING.conf
+++ b/configs/Gigabyte/X470-AORUS-ULTRA-GAMING.conf
@@ -1,0 +1,90 @@
+# Experimental config for Gigabyte X470 AORUS ULTRA GAMING
+# https://www.gigabyte.com/Motherboard/X470-AORUS-ULTRA-GAMING-rev-10
+#
+# This config is based on:
+#   - GA-AB350-GAMING3.conf
+#   - GA-AX370-GAMING5.conf
+#   - output of HWiNFO64 Sensor Status program on Windows
+
+# The temp3 temperature offset depends on the CPU type and needs to be
+# adjusted. Compare against the output of k10temp for the correct value.
+# I've tested with my AMD Ryzen 5 2600 and a difference between temp3 and Tdie (from k10temp)
+# is usually very small so I personally don't use any adjustment of that field.
+
+chip "it8686-isa-0a40"
+    label temp1 "System 1"
+    label temp2 "Chipset"
+    label temp3 "CPU Socket"
+    label temp4 "PCIEX16"
+    label temp5 "VRM MOS"
+    label temp6 "VSOC MOS"
+    label in0 "CPU Vcore"
+    label in1 "+3.3V"
+    label in2 "+12V"
+    label in3 "+5V"
+    label in4 "CPU Vcore SOC"
+    label in5 "CPU Vddp"
+    label in6 "DRAM A/B"
+#   label in7 "3VSB"
+#   label in8 "Battery"
+    label fan1 "CPU_FAN"
+    label fan2 "SYS_FAN1"
+    label fan3 "SYS_FAN2"
+    label fan4 "SYS_FAN3"
+    label fan5 "CPU_OPT"
+
+#   compute temp3 @+0.5,@+0.5
+    compute in1 @*1.65,@*1.65
+    compute in2 @*6,@*6
+    compute in3 @*2.5,@*2.5
+
+    set in0_min 0.35
+    set in0_max 1.45
+    set in1_min 3.3 * 0.97
+    set in1_max 3.3 * 1.03
+    set in2_min 12 * 0.97
+    set in2_max 12 * 1.03
+    set in3_min 5 * 0.97
+    set in3_max 5 * 1.03
+    set in4_min 0.9
+    set in4_max 1.26
+    set in5_min 0.9 * 0.95
+    set in5_max 0.9 * 1.05
+    set in6_min 1.1
+    set in6_max 1.6
+
+chip "it8792-isa-0a60"
+    label temp1 "PCIEX8"
+    label temp2 "Temp 2"
+    label temp3 "System 2"
+    label in0 "CPU Vcore"
+    label in1 "DDR VTT"
+    label in2 "Chipset Core"
+#   label in3 "VIN3"
+    label in4 "CPU Vdd18"
+    label in5 "DDR Vpp A/B"
+#   label in6 "3VSB"
+#   label in7 "Battery"
+    label fan1 "SYS_FAN5_PUMP"
+    label fan2 "SYS_FAN6_PUMP"
+    label fan3 "SYS_FAN4"
+
+    compute in5 @ * (208/125), @ / (208/125)
+
+    set in0_min 0.35
+    set in0_max 1.45
+    set in1_min 1.1 / 2
+    set in1_max 1.6 / 2
+    set in2_min 1.05 * 0.95
+    set in2_max 1.05 * 1.05
+    set in4_min 1.8 * 0.97
+    set in4_max 1.8 * 1.03
+    set in5_min 2.5 * 0.95
+    set in5_max 2.5 * 1.05
+    set in7_min 3.3 * 0.97
+    set in7_max 3.3 * 1.03
+
+#   ignore fan1
+#   ignore fan2
+#   ignore fan3
+#   ignore in8

--- a/configs/Gigabyte/X470-AORUS-ULTRA-GAMING.conf
+++ b/configs/Gigabyte/X470-AORUS-ULTRA-GAMING.conf
@@ -55,7 +55,7 @@ chip "it8686-isa-0a40"
 
 chip "it8792-isa-0a60"
     label temp1 "PCIEX8"
-    label temp2 "Temp 2"
+    label temp2 "EC_TEMP"
     label temp3 "System 2"
     label in0 "CPU Vcore"
     label in1 "DDR VTT"


### PR DESCRIPTION
Initial config for Gigabyte X470 AORUS ULTRA GAMING
https://www.gigabyte.com/Motherboard/X470-AORUS-ULTRA-GAMING-rev-10
   
This config is based on:
      - GA-AB350-GAMING3.conf
      - GA-AX370-GAMING5.conf
      - output of HWiNFO64 Sensor Status program on Windows