### PR TITLE
configs: add Supermicro X7DCL

### DIFF
--- a/configs/SuperMicro/X7DCL.conf
+++ b/configs/SuperMicro/X7DCL.conf
@@ -1,0 +1,80 @@
+bus "i2c-0" "SMBus I801 adapter at 1100"
+chip "w83793-i2c-0-2f"
+
+# 0x10, CPU Core 1
+    label in0 "CPU Core 1"
+# 0x11, CPU Core 2
+    label in1 "CPU Core 2"
+# 0x12 VTT=1.2V in BIOS ?
+    label in2 "VTT"
+    set in2_min 1.2*0.95
+    set in2_max 1.2*1.05
+# 0x14, -12V
+    label in3 "-12V"
+    compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8
+    set in3_min -12*1.05
+    set in3_max -12*0.95
+# 0x15, DIMM
+    label in4 "P1V5"
+# 0x16, +3.3V
+    label in5 "+3.3V"
+    set in5_min 3.3*0.95
+    set in5_max 3.3*1.05
+# 0x17, +12V
+    label in6 "+12V"
+    compute in6 @*12,@/12
+    set in6_min 12*0.95
+    set in6_max 12*1.05
+# Ox18, +5V
+    label in7 "+5V"
+    set in7_min 5*0.95
+    set in7_max 5*1.05
+# 0x19, 5VSB
+    label in8 "5VSB"
+    set in8_min 5*0.95
+    set in8_max 5*1.05
+# 0x1a, Battery Voltage
+    label in9 "VBAT"
+
+    label temp1 "CPU1 Temp"
+    label temp2 "CPU2 Temp"
+    ignore temp3
+    ignore temp4
+    label temp5 "System Temp"
+
+    label fan1 "CPU1 fan"
+    label fan2 "CPU2 fan"
+    label fan3 "Fan 3"
+    label fan4 "Fan 4"
+    label fan5 "Fan 5"
+    label fan6 "Fan 6"
+    ignore fan7
+    ignore fan8
+    ignore fan9
+    ignore fan10
+    ignore fan11
+    ignore fan12
+
+    label intrusion0 "Intrusion"
+    ignore beep_enable
+
+
+chip "w83627hf-isa-0290"
+    # no driver access to GP11, so I turned off everything.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore cpu0_vid
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore temp1
+    ignore temp2
+    ignore temp3
+    ignore beep_enable


### PR DESCRIPTION
Add configuration for Supermicro X7DCL motherboard.
Based on slightly modified setup of X7DBE from this repo.
Runtime tested on X7DCL-3 rev. 1.1a

So far there is only support for onboard sensors,
no support for PSU failure yet, nor external PMBus sensors.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>