### PR TITLE
sensors-detect: Add F81966 & F81804 support

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2448,6 +2448,12 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x04,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Fintek F81966D/Fintek F81804 Super IO Sensors",
+		driver => "f71882fg",
+		devid => 0x1502,
+		logdev => 0x04,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Asus F8000 Super IO",
 		driver => "f71882fg",
 		devid => 0x0581,


### PR DESCRIPTION
Add support for Fintek F81966 & Fintek F81804 support.
Both chips have same chip id and register for hwmon relevant driver.

HWMON driver support is actually in the pipeline.