### PR TITLE
Add configs for ASUS MB P10S-M WS

### DIFF
--- a/configs/Asus/P10S-M_WS.conf
+++ b/configs/Asus/P10S-M_WS.conf
@@ -1,0 +1,61 @@
+# Asus P10S-M WS
+chip   "nct6791-*"
+    ignore temp1 # -62.0 all the time
+    ignore temp2 # -45.0
+    ignore temp3 # 23.0 all the time
+    ignore temp4 # 26.0 all the time
+    ignore temp6 # -62.0
+    # temp8 - temp10 always 0
+    ignore temp8
+    ignore temp9
+    ignore temp10
+    label temp7 "CPU"
+    label temp5 "MB"
+
+    label in0 "VCORE"
+
+    ignore in2 # same as in3
+    ignore in5 # 2040 all the time
+    ignore in11 # same as VCCIO (in9)
+    ignore in13 # same as in9
+    ignore in14 # 2040 all the time
+
+    label in1 "+5V"
+    compute in1 @ * 5, @ / 5
+    set in1_min 5 * 0.95
+    set in1_max 5 * 1.05
+
+    label in3 "+3.3V"
+    set in3_min 3.3 * 0.95
+    set in3_max 3.3 * 1.05
+
+    label in4 "+12V"
+    compute in4 @ * 12, @ / 12
+    set in4_min 12 * 0.95
+    set in4_max 12 * 1.05
+
+    label in6 "VCCSA"
+
+    label in7 "+3.3VSB"
+    set in7_min 3.3 * 0.95
+    set in7_max 3.3 * 1.05
+
+    label in9 "VCCIO"
+
+    label in10 "+5VSB"
+    compute in10 @ * 5, @ / 5
+    set in10_min 5 * 0.95
+    set in10_max 5 * 1.05
+
+    label in12 "VDDQ_AB_CPU1"
+
+    label fan1 "REAR_FAN"
+    label fan2 "CPU_FAN1"
+    label fan3 "FRNT_FAN1"
+    label fan4 "FRNT_FAN2"
+    label fan5 "FRNT_FAN3"
+    label fan6 "FRNT_FAN4"
+
+    #ignore intrusion0
+    #ignore intrusion1
+    ignore beep_enable


### PR DESCRIPTION
Add configs for Asus motherboard **P10S-M WS**, which is very similar to **H87-Pro**.