### PR TITLE
configs: fix Supermicro X7DCL VTT limits

### DIFF
--- a/configs/SuperMicro/X7DCL.conf
+++ b/configs/SuperMicro/X7DCL.conf
@@ -5,10 +5,10 @@ chip "w83793-i2c-0-2f"
     label in0 "CPU Core 1"
 # 0x11, CPU Core 2
     label in1 "CPU Core 2"
-# 0x12 VTT=1.2V in BIOS ?
+# 0x12 VTT=1.1V in BIOS
     label in2 "VTT"
-    set in2_min 1.2*0.95
-    set in2_max 1.2*1.05
+    set in2_min 1.1*0.95
+    set in2_max 1.1*1.05
 # 0x14, -12V
     label in3 "-12V"
     compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8


### PR DESCRIPTION
According to:
"Quad-Core Intel® Xeon(R) Processor 5400 Series Electrical Specifications"
(table 2-12), FSB termination voltage of the CPUs (VTT) is 1.1V +/-5%.
Initial configuration set it to 1.2V - fix that.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>