### PR TITLE
Add driver for Fintek F75387SG/RG to sensors-detect

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -1441,7 +1441,7 @@ use vars qw(@i2c_adapter_names);
 		i2c_detect => sub { fintek_detect(@_, 4); },
 	}, {
 		name => "Fintek F75387SG/RG",
-		driver => "to-be-written",
+		driver => "f75375s",
 		i2c_addrs => [0x2d..0x2e],
 		i2c_detect => sub { fintek_detect(@_, 5); },
 	}, {


### PR DESCRIPTION
Support for the Fintek F75387SG/RG was added to driver f75375s back in 2013 according to https://hwmon.wiki.kernel.org/device_support_status_d_f. Works perfectly on my computer.