### PR TITLE
Add new Nuvoton Super IO Sensors

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2337,6 +2337,13 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x0b,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Nuvoton NCT6797D Super IO Sensors",
+		driver => "nct6775",
+		devid => 0xD450,
+		devid_mask => 0xFFF0,
+		logdev => 0x0b,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Nuvoton NCT6102D/NCT6104D/NCT6106D Super IO Sensors",
 		driver => "nct6775",
 		devid => 0xC450,

--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2344,6 +2344,13 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x0b,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Nuvoton NCT6798D Super IO Sensors",
+		driver => "nct6775",
+		devid => 0xD428,
+		devid_mask => 0xFFF8,
+		logdev => 0x0b,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Nuvoton NCT6102D/NCT6104D/NCT6106D Super IO Sensors",
 		driver => "nct6775",
 		devid => 0xC450,


### PR DESCRIPTION
NCT6797D is found on MPG X570 GAMING PLUS
For NCT6798D I don't have any HW using it but it's supported by the nct6775 driver