### PR TITLE
makefile: use compiler target arch when determining what programs to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ LIBINCLUDEDIR := $(INCLUDEDIR)/sensors
 # manual pages will be installed.
 MANDIR := $(PREFIX)/man
 
-MACHINE := $(shell uname -m)
+ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine)))
 
 # Extra non-default programs to build; e.g., sensord
 #PROG_EXTRA := sensord
@@ -109,7 +109,7 @@ BUILD_STATIC_LIB := 1
 SRCDIRS := lib prog/detect prog/pwm \
            prog/sensors ${PROG_EXTRA:%=prog/%} etc
 # Only build isadump and isaset on x86 machines.
-ifneq (,$(findstring $(MACHINE), i386 i486 i586 i686 x86_64))
+ifneq (,$(findstring $(ARCH), i386 i486 i586 i686 x86_64))
 SRCDIRS += prog/dump
 endif
 SRCDIRS += lib/test


### PR DESCRIPTION
`uname -m` lists the host machine architecture. To support cross-compilation
the Makefile should detect the compiler's target architecture. This approach
uses the `gcc`/`clang` compatible `-dumpmachine` option and parses the first
word in the tuple representing the target architecture.

Renaming `MACHINE` to `ARCH` to match cross-compiler conventions for
specifying the target architecture (e.g.
`make ARCH=arm CC=arm-linux-gnueabi-gcc`)

Just like for PPC the `isadump` and `isaset` tools should not be compiled
on ARM. This has the side affect of "fixing" the ARM build with glibc-2.30,
which removed `sys/io.h` I/O port functions.

Fixes #190

Signed-off-by: Lucas Magasweran <lucas.magasweran@ieee.org>