### PR TITLE
Fixes Fahrenheit missing conversion for JSON and RAW output modes

### DIFF
--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -34,6 +34,11 @@
 
 static void scale_value(double *value, const char **prefixstr);
 
+static inline double deg_ctof(double cel)
+{
+	return cel * (9.0F / 5.0F) + 32.0F;
+}
+
 void print_chip_raw(const sensors_chip_name *name)
 {
 	int a, b, err;
@@ -60,18 +65,16 @@ void print_chip_raw(const sensors_chip_name *name)
 						"value of subfeature %s: %s\n",
 						sub->name,
 						sensors_strerror(err));
-				else
+				else {
+					if (fahrenheit)
+						val = deg_ctof(val);
 					printf("  %s: %.3f\n", sub->name, val);
+				}
 			} else
 				printf("(%s)\n", label);
 		}
 		free(label);
 	}
-}
-
-static inline double deg_ctof(double cel)
-{
-	return cel * (9.0F / 5.0F) + 32.0F;
 }
 
 void print_chip_json(const sensors_chip_name *name)

--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -69,6 +69,11 @@ void print_chip_raw(const sensors_chip_name *name)
 	}
 }
 
+static inline double deg_ctof(double cel)
+{
+	return cel * (9.0F / 5.0F) + 32.0F;
+}
+
 void print_chip_json(const sensors_chip_name *name)
 {
 	int a, b, cnt, subCnt, err;
@@ -102,6 +107,8 @@ void print_chip_json(const sensors_chip_name *name)
 				} else {
 					if (subCnt > 0)
 						printf(",\n");
+					if (fahrenheit)
+						val = deg_ctof(val);
 					printf("         \"%s\": %.3f", sub->name, val);
 					subCnt++;
 				}
@@ -120,11 +127,6 @@ void print_chip_json(const sensors_chip_name *name)
 }
 
 static const char hyst_str[] = "hyst";
-
-static inline double deg_ctof(double cel)
-{
-	return cel * (9.0F / 5.0F) + 32.0F;
-}
 
 static void print_label(const char *label, int space)
 {


### PR DESCRIPTION
Hey there !

Back in 2017 when the `-j` option has been added (1b36ea429930b05e1b3cb77cdbc24cb1ffbcac61), the Fahrenheit conversion has not been implemented.
This quick-and-dirty patch fixes this behavior, making both `-j` and `-f` options _compatible_.
It has been tested on my own Debian system.

Bye :wave:

EDIT : New commit added afterwards relative to the `-u` (raw output) flag.