### PR TITLE
GA-870A-USB3.conf: Better scaling for +12V reading

### DIFF
--- a/configs/Gigabyte/GA-870A-USB3.conf
+++ b/configs/Gigabyte/GA-870A-USB3.conf
@@ -33,10 +33,10 @@ chip "it8720-isa-*"
    # "Vcore", "DDR3 1.5V", "+3.3V" and "Vbat" are connected directly, so no compute
    # line is needed for these. +5V and 5VSB are internal so we use the
    # standard scaling factor. Scaling for +12V is apparently being done with 
-   # 5.3kOhm and 2.7kOhm resistors, this matches my BIOS reading. It's an improvement
+   # 8kOhm and 2.7kOhm resistors, this matches my BIOS reading. It's an improvement
    # from the previous proposed scaling value of 3.963.
    compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
-   compute  in4  @ * (5.3/2.7+1),@ / (5.3/2.7+1)
+   compute  in4  @ * (8/2.7+1),@ / (8/2.7+1)
    compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
 
    # The BIOS will not set any limit for voltages.

--- a/configs/Gigabyte/GA-870A-USB3.conf
+++ b/configs/Gigabyte/GA-870A-USB3.conf
@@ -32,11 +32,11 @@ chip "it8720-isa-*"
 
    # "Vcore", "DDR3 1.5V", "+3.3V" and "Vbat" are connected directly, so no compute
    # line is needed for these. +5V and 5VSB are internal so we use the
-   # standard scaling factor. Scaling for +12V is apparently not standard,
-   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
-   # another candidate.)
+   # standard scaling factor. Scaling for +12V is apparently being done with 
+   # 5.3kOhm and 2.7kOhm resistors, this matches my BIOS reading. It's an improvement
+   # from the previous proposed scaling value of 3.963.
    compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
-   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in4  @ * (5.3/2.7+1),@ / (5.3/2.7+1)
    compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
 
    # The BIOS will not set any limit for voltages.


### PR DESCRIPTION
Apparently, Gigabyte uses a 5.3kOhm and a 2.7kOhm resistor for the voltage divider (both are commercially available SMD resistors). It matches my BIOS reading.