### PR TITLE
Asus TUF GAMING X570 PLUS (Wi-Fi) motherboard

### DIFF
--- a/configs/Asus/TUF-GAMING-X570-PLUS.conf
+++ b/configs/Asus/TUF-GAMING-X570-PLUS.conf
@@ -1,0 +1,88 @@
+chip "nct6798-*"
+# nct6776 values for Asus TUF GAMING X570-PLUS (WI-FI)
+# I'm not entirely sure everything here is correct since no HW monitoring application under Windows shows
+# all the names for all the found sensors. Some of the names and formulas are best guesstimates and could be wrong.
+# You will have to unignore fans and intrusion if you want them to be monitored - I don't have them, I've hidden them
+
+label in0 "Vcore"
+    set in0_min 0.2
+    set in0_max 1.5
+
+# in1
+    set in1_min 0.95
+    set in1_max 1.05
+
+label in2 "AVSB"
+    set in2_min  3.3 * 0.95
+    set in2_max  3.3 * 1.05
+
+label in3 "3VCC"
+    set in3_min  3.3 * 0.95
+    set in3_max  3.3 * 1.05
+
+label in4 "+12V"
+    compute in4 @ * 12, @ / 12
+    set in4_min  12 * 0.95
+    set in4_max  12 * 1.05
+
+# in5
+    set in5_min  0.7
+    set in5_max  0.85
+
+label in6 "+5V"
+    compute in6 @ * 5, @ / 5
+    set in6_min  5 * 0.95
+    set in6_max  5 * 1.05
+
+label in7 "3.3V"
+    set in7_min  3.3 * 0.95
+    set in7_max  3.3 * 1.05
+
+label in8 "Vbat"
+    set in8_min  3.3 * 0.95
+    set in8_max  3.3 * 1.05
+
+# in9
+    set in9_min 0.85
+    set in9_max 0.95
+
+# always shows a constant value after boot - ether 0.272 or 0.288
+ignore in10
+
+# constant 0.544
+ignore in11
+
+# constant 1.032
+ignore in12
+
+# in13
+    set in13_min 0.95
+    set in13_max 1.05
+
+# in14
+    set in14_min 0.95
+    set in14_max 1.05
+
+ignore fan1
+
+label fan2 "CPU Fan"
+    set fan2_min 200
+
+ignore fan3
+ignore fan4
+
+# No idea what's the minimum but let's put 1000 in since this fan must always work
+label fan5 "PCH Fan"
+    set fan5_min 1000
+
+ignore fan6
+ignore fan7
+
+# Always show zeros
+ignore temp8
+ignore temp9
+ignore temp10
+
+# I have an open case
+ignore intrusion0
+ignore intrusion1


### PR DESCRIPTION
This is actually a config for TUF GAMING X570-PLUS (Wi-Fi) but I'm quite sure these two motherboards share sensors configuration.