### PR TITLE
configs: Add MSI B450M Mortar board

### DIFF
--- a/configs/MSI/MS-7B89-B450M-MORTAR.conf
+++ b/configs/MSI/MS-7B89-B450M-MORTAR.conf
@@ -1,0 +1,100 @@
+# MS-7B89 B450-MORTAR config
+#
+# Based on MS-7A34 B350-TOMAHAWK config
+# unknown labels taken from MS-7B79 X470 GAMING PRO config
+#
+# Tested on a B450M Mortar Titanium board,
+# but it shares the same ID with the B450M Mortar board.
+
+chip "nct6797-*"
+	label in0 "Vcore"
+	set in0_min 0.4
+	set in0_max 1.45 # max recommended voltage
+
+	label in1 "ATX 5V"
+	compute in1 ((12 / 3) + 1) * @, @ / ((12 / 3) + 1)
+	set in1_min 5 * 0.95
+	set in1_max 5 * 1.05
+
+	label in2 "AVCC Analog"
+	set in2_min 3.3 * 0.95  # assume ATX ±5% is enough
+	set in2_max 3.3 * 1.05  # assume ATX ±5% is enough
+
+	label in3 "ATX 3.3V"
+	set in3_min 3.3 * 0.95  # ATX 2.4
+	set in3_max 3.3 * 1.05  # ATX 2.4
+
+	label in4 "ATX 12V"
+	compute in4 ((220 / 20) + 1) * @, @ / ((220 / 20) + 1)
+	set in4_min 12 * 0.95
+	set in4_max 12 * 1.05
+
+	# no VIN8 input in this chip?
+	ignore in5
+
+	# likely AUXTIN0 thermistor
+	ignore in6
+
+	label in7 "3VSB Standby"
+	set in7_min 3.3 * 0.95  # assume ATX ±5% is enough
+	set in7_max 3.3 * 1.05  # assume ATX ±5% is enough
+
+	label in8 "RTC Battery"
+	set in8_min 2.0  # from Intel 200-series chipset spec
+	set in8_max 3.4  # from random CR2032 datasheet
+
+	label in9 "CPU 1.8V"
+	set in9_min  1.82 * 0.90
+	set in9_max  1.82 * 1.10
+
+	# might read as 0V if a CPU without iGPU is installed
+	label in10 "CPU VDDP"
+
+	# likely AUXTIN2 thermistor
+	ignore in11
+
+	label in12 "Vsoc"
+	set in12_min  0.8
+	set in12_max  1.45 #max rating
+
+	label in13 "Vdram"
+	compute in13 2 * @, @ / 2
+	set in13_min  1.1 # DDR min voltage
+	set in13_max  1.5 # DDR max voltage
+
+	label in14 "5VSB Standby"
+	compute in14 ((768 / 330) + 1) * @, @ / ((768 / 330) + 1)
+	set in14_min 5 * 0.95
+	set in14_max 5 * 1.05
+
+
+	ignore fan1
+	label fan2 "CPU 1"
+	label fan3 "SYSTEM 1"
+	label fan4 "SYSTEM 2"
+	label fan5 "SYSTEM 3"
+
+
+	label temp1 "Super I/O"
+	label temp2 "SoC VRM"
+	label temp3 "CPU VRM"
+
+	# AUXTIN1 is used as VIN5
+	ignore temp4
+
+	# Termistor Chipset?
+	label temp5 "PCH"
+
+	# AUXTIN3 is used as VIN7
+	ignore temp6
+
+	# the same temperature as reported by k10temp
+	label temp7 "CPU die"
+
+	# stuck at 0°C
+	ignore temp8
+	ignore temp9
+	ignore temp10
+
+	# likely DEEP_S5 signal
+	ignore intrusion1


### PR DESCRIPTION
Tested on a B450M Mortar Titanium board, but it shares the same ID with the B450M Mortar board.