### PR TITLE
config: Asrock J5005-ITX motherboard

### DIFF
--- a/configs/ASRock/J5005-ITX.conf
+++ b/configs/ASRock/J5005-ITX.conf
@@ -40,6 +40,7 @@ chip "nct6796-*"
 	set	in8_min	3.30 * 0.90
 	set	in8_max	3.30 * 1.10
 
+	# Not sure about in14(VIN7) it seems to be mapped to a 5V bus.
 	label	in14	"VIN7"		# VIN7
 	compute	in14	@*(24/8), @/(24/8)
 	set	in14_min 5.00 * 0.90

--- a/configs/ASRock/J5005-ITX.conf
+++ b/configs/ASRock/J5005-ITX.conf
@@ -14,7 +14,7 @@ chip "nct6796-*"
 	set	in0_max	1.46
 	set	in0_beep 1
 
-	label	in1	"+12V"		# Vin1
+	label	in1	"+12V"		# VIN1
 	compute	in1	@*(53/8), @/(53/8)
 	set	in1_min	12.0 * 0.90
 	set	in1_max	12.0 * 1.10

--- a/configs/ASRock/J5005-ITX.conf
+++ b/configs/ASRock/J5005-ITX.conf
@@ -1,0 +1,85 @@
+# libsensors configuration file
+# -----------------------------
+#
+# Motherboard: Asrock J5005-ITX
+# DMI: To Be Filled By O.E.M. To Be Filled By O.E.M./J5005-ITX, BIOS P1.40 08/06/2018
+# SuperIO chip: NCT6796D
+chip "nct6796-*"
+
+	set beep_enable 1
+
+	# Voltages:
+	label	in0	"Vcore"		# CPUVCORE
+	set	in0_min	0.16
+	set	in0_max	1.46
+	set	in0_beep 1
+
+	label	in1	"+12V"		# Vin1
+	compute	in1	@*(53/8), @/(53/8)
+	set	in1_min	12.0 * 0.90
+	set	in1_max	12.0 * 1.10
+
+	label	in2	"AVCC"		# AVSB
+	set	in2_min	3.30 * 0.90
+	set	in2_max	3.30 * 1.10
+
+	label	in3	"+3.3V"		# 3VCC
+	set	in3_min	3.30 * 0.90
+	set	in3_max	3.30 * 1.10
+
+	label	in4	"+5V"		# VIN0
+	compute	in4	@*(24/8), @/(24/8)
+	set	in4_min	5.00 * 0.90
+	set	in4_max	5.00 * 1.10
+
+	label	in7	"3VSB"		# 3VSB
+	set	in7_min	3.30 * 0.90
+	set	in7_max	3.30 * 1.10
+
+	label	in8	"VBAT"		# VBAT
+	set	in8_min	3.30 * 0.90
+	set	in8_max	3.30 * 1.10
+
+	label	in14	"VIN7"		# VIN7
+	compute	in14	@*(24/8), @/(24/8)
+	set	in14_min 5.00 * 0.90
+	set	in14_max 5.00 * 1.10
+
+	# these have zero input
+	ignore	in9			# VTT
+	ignore	in15			# VIN9	(no support in driver nct6775.c)
+
+	# these have non-zero input, but are unknown
+	ignore	in5			# VIN8
+	ignore	in6			# VIN4
+	ignore	in10			# VIN5
+	ignore	in11			# VIN6
+	ignore	in12			# VIN2
+	ignore	in13			# VIN3
+
+	# Temperatures:
+	label	temp1	"M/B temp"	# SYSTIN
+	label	temp2	"CPU temp"	# CPUTIN
+	ignore	temp3			# AUXTIN0
+	ignore	temp4			# AUXTIN1
+	ignore	temp5			# AUXTIN2
+	ignore	temp6			# AUXTIN3
+
+	ignore	temp7			# PCH_CHIP_CPU_MAX_TEMP
+	ignore	temp8			# PCH_CHIP_TEMP
+	ignore	temp9			# PCH_CPU_TEMP
+	ignore	temp10			# PCH_MCH_TEMP
+
+	# Fans:
+	ignore	fan0
+	label	fan1	"SYS fan"
+	label	fan2	"CPU fan"
+	ignore	fan3
+	ignore	fan4
+	ignore	fan5
+	ignore	fan6
+	ignore	fan7
+
+	# Misc:
+	label	intrusion0 "Case open"	# CASEOPEN0#
+	ignore	intrusion1		# CASEOPEN1#


### PR DESCRIPTION
Support for J5005-ITX motherboard, most likely also for J4005B-ITX board.

Noticed in the documentation that the NCT6796D actually has 16 analog
voltage inputs, where only 15 are configured.
Not sure about in14(VIN7) it seems to be mapped to a 5V bus.