### PR TITLE
Change PIDFile path from /var/run to /run in systemd service units

### DIFF
--- a/prog/init/fancontrol.service
+++ b/prog/init/fancontrol.service
@@ -5,7 +5,7 @@ After=lm_sensors.service
 
 [Service]
 Type=simple
-PIDFile=/var/run/fancontrol.pid
+PIDFile=/run/fancontrol.pid
 ExecStart=/usr/sbin/fancontrol
 
 [Install]

--- a/prog/init/sensord.service
+++ b/prog/init/sensord.service
@@ -5,7 +5,7 @@ After=lm_sensors.service
 [Service]
 EnvironmentFile=/etc/sysconfig/sensord
 Type=forking
-PIDFile=/var/run/sensord.pid
+PIDFile=/run/sensord.pid
 ExecStart=/usr/sbin/sensord -i $INTERVAL -l $LOG_INTERVAL -f daemon
 
 [Install]


### PR DESCRIPTION
/var/run is considered a legacy directory by systemd 239+ and having it in unit files causes a warning to be emitted to the journal.

Example warning:
```
/usr/lib/systemd/system/sensord.service:8: PIDFile= references a path below legacy directory /var/run/, updating /var/run/sensord.pid → /run/sensord.pid; please update the unit file accordingly.
```

systemd change reference:
https://github.com/systemd/systemd/commit/a2d1fb882c4308bc10362d971f333c5031d60069