### PR TITLE
configs: Add entry for GA-AB350N-Gaming WIFI (rev. 1.0)

### DIFF
--- a/configs/Gigabyte/GA-AB350N-GAMING-WIFI-REV1.0.conf
+++ b/configs/Gigabyte/GA-AB350N-GAMING-WIFI-REV1.0.conf
@@ -1,0 +1,86 @@
+# GA-AB350N-Gaming WIFI (rev. 1.0)
+
+chip "it8686-isa-0a40"
+  label temp1 "System 1"
+  label temp2 "Chipset"
+  label temp3 "CPU Socket"
+  label temp4 "PCI-EX16"
+  label temp5 "VRM MOS"
+  label temp6 "vSOC MOS"
+
+  label in0 "CPU Vcore"
+  label in1 "+3.3v"
+  label in2 "+12v"
+  label in3 "+5v"
+  label in4 "CPU Vcore SOC"
+  label in5 "CPU VDDP"
+  label in6 "DRAM A/B"
+  label in7 "3VSB"
+  label in8 "Battery"
+
+  label fan1 "CPU_FAN"
+  label fan2 "SYS_FAN1"
+
+  compute in1 @*1.650,@/1.650
+  compute in2 @*6,@/6
+  compute in3 @*2.5,@/2.5
+
+  set temp1_min 15
+  set temp1_max 65
+  set temp2_min 15
+  set temp2_max 80
+  set temp3_min 15
+  set temp3_max 85
+  set temp4_min 15
+  set temp4_max 30
+  set temp5_min 15
+  set temp5_max 95
+  set temp6_min 15
+  set temp6_max 90
+
+  set in0_min 0.6
+  set in0_max 1.45
+  set in1_min 3.135
+  set in1_max 3.465
+  set in2_min 11.400
+  set in2_max 12.600
+  set in3_min 4.750
+  set in3_max 5.250
+  set in6_min 1.2 * 0.97
+  set in6_max 1.2 * 1.2
+  set in7_min 3.3 * 0.97
+  set in7_max 3.3 * 1.05
+
+  set fan1_min 900
+  set fan2_min 900
+  
+chip "it8792-isa-0a60"
+  label temp1 "PCI-EX8"
+  label temp2 "Temp 2"
+  label temp3 "System 2"
+
+  label in0 "CPU Vcore"
+  label in1 "DDR VTT"
+  label in2 "Chipset Core"
+  label in3 "VIN3"
+  label in4 "CPU VDD18"
+  label in5 "DDR VPP"
+  label in7 "3VSB"
+  label in8 "VBAT"
+
+  set temp1_min 15
+  set temp1_max 60
+  set temp2_min 15
+  set temp2_max 60
+  set temp3_min 15
+  set temp3_max 60
+
+  set in0_min 0.6
+  set in0_max 1.45
+  set in7_min 3.135
+  set in7_max 3.465
+
+  ignore in6
+  ignore fan1
+  ignore fan2
+  ignore fan3


### PR DESCRIPTION
I've not written configs for lm-sensors before so input is welcome. I used the manual and images provided by the manufacture to write this config along with a large amount of screenshots from HWiNFO64 from Windows.