### PR TITLE
configs: Add DMI information for GA-AB350N-Gaming WIFI (rev. 1.0)

### DIFF
--- a/configs/Gigabyte/GA-AB350N-GAMING-WIFI-REV1.0.conf
+++ b/configs/Gigabyte/GA-AB350N-GAMING-WIFI-REV1.0.conf
@@ -1,5 +1,10 @@
 # GA-AB350N-Gaming WIFI (rev. 1.0)
 
+# dmi: board_name: AB350N-Gaming WIFI-CF
+# dmi: board_vendor: Gigabyte Technology Co., Ltd.
+# dmi: board_version: x.x
+# dmi: bios_version: F50a
+
 chip "it8686-isa-0a40"
   label temp1 "System 1"
   label temp2 "Chipset"


### PR DESCRIPTION
Hopefully this commit message is a bit better than my other attempt, sorry for all the trouble.