### PR TITLE
sensors-detect: Add support for AMD CPU Family 19h

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2797,6 +2797,10 @@ use vars qw(@cpu_ids);
 		driver => "k10temp",
 		detect => sub { amd_pci_detect('1463', '15d0', '1493', '1443') },
 	}, {
+		name => "AMD Family 19h thermal sensors",
+		driver => "k10temp",
+		detect => sub { amd_pci_detect('1653') },
+	}, {
 		name => "AMD Family 15h power sensors",
 		driver => "fam15h_power",
 		detect => sub {


### PR DESCRIPTION
Enable sensors-detect support for AMD Zen3 (Family 19h) CPUs. This PCI ID
is derived from Linux kernel PCI_DEVICE_ID_AMD_19H_DF_F3.

Signed-off-by: Wei Huang <huangwei@gmail.com>