### PR TITLE
Config for ASRock Z390M ITX

### DIFF
--- a/configs/ASRock/Z390M-ITX-ac.conf
+++ b/configs/ASRock/Z390M-ITX-ac.conf
@@ -1,0 +1,162 @@
+# Board: ASRock Z390M-ITX/ac
+# Contributed by: Aaron Bockelie
+# Processor: Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz (6/158/10)
+# Board has connectors for buzzer and 3 fans (2 case + 1 CPU)
+# board does not have a connector for intrusion detection
+# dmesg: "nct6775: Found NCT6793D or compatible chip at 0x2e:0x290"
+
+chip "nct6793-*"
+
+   # Cross referenced with ASRock A-Tuning Application on 6/29/2020
+   # Install in Windows and see /Program Files (x86)/ASRock Utility/A-Tuning/Conf/Z390MITX.xml
+   # There is also an NCT3933U on the board for measuring the PCH and VCCST voltages, but it
+   # is not accessible due to no kernel driver for it.
+   
+   # Referenced from NCT677xF (NCT6793D) Data Sheet Page 57
+   # All the internal inputs of the ADC, AVSB, VBAT, 3VSB, and 3VCC utilize an integrated voltage
+   # divider with both resistors equal to 34K, yielding a voltage one half of the power supply.
+   # Vin = VCC * (34K/(34K+34K)=1.65V where VCC is set to 3.3V
+   
+   # ID   NCTSpec   NCTDesc    ASRock Utility Description
+   # in0  index80   CPUVCORE   CPU_INPUT_V (Interface IR35201)
+   # in1  index81   VIN1       <none>
+   # in2  index82   AVSB       <none>
+   # in3  index83   3VCC       P3P3_V
+   # in4  index84   VIN0       <none>
+   # in5  N/A       N/A        N/A
+   # in6  index86   VIN4       SIO3_V
+   # in7  index87   3VSB       <none>
+   # in8  index88   VBAT       <none>
+   # in9  index89   VTT        <none>
+   # in10 index8a   VIN5       <none>, SIO6_V
+   # in11 index8b   VIN6       <none>, SIO4_V
+   # in12 index8c   VIN2       P12_V, SIO1_V
+   # in13 index8d   VIN3       P5P0_V, SIO2_V
+   # in14 index8e   VIN7       SIO5_V
+ 
+   
+   set beep_enable 1
+
+   # voltages
+   # The CPUVCORE pin feeds directly into the ADC with no voltage divider since the nominal
+   # voltage on this pin is only 1.2V
+   
+   label   in0     "Vcore"
+   compute in0 @*2, @/2
+   set     in0_min 0.16
+   set     in0_max 1.48
+   set     in0_beep 1
+   
+   ignore  in1
+  
+   label   in2     "AVCC"
+   set     in2_min 3.30 * 0.90
+   set     in2_max 3.30 * 1.10
+
+   label   in3     "+3.3V"
+   set     in3_min 3.30 * 0.90
+   set     in3_max 3.30 * 1.10
+   
+   ignore  in4
+   
+   ignore  in5
+   
+   ignore  in6
+
+   label   in7     "3VSB"
+   set     in7_min 3.30 * 0.90
+   set     in7_max 3.30 * 1.10
+   
+   # This is the CMOS battery.
+   
+   label   in8     "VBATT"
+   set     in8_min 3.3 * 0.75
+   set     in8_max 3.3 * 1.10
+   
+   label   in9     "VTT"
+   set     in9_min 1.2 * 0.90
+   set     in9_max 1.2 * 1.25
+
+   ignore  in10
+
+   ignore  in11
+
+   label   in12     "+12V"
+   #((56+10)/10)
+   compute in12 @*6.6, @/6.6
+   set     in12_min 12 * 0.95
+   set     in12_max 12 * 1.05
+
+   label   in13     "+5V"
+   compute in13 @*(24/8), @/(24/8)
+   set     in13_min 5 * 0.90
+   set     in13_max 5 * 1.10
+
+   ignore  in14
+   
+   
+   # temperatures
+   # see NCT677xF (NCT6793D) Data Sheet Section 8.5.3.4 Temperature Reading
+   # a customized nct6775 kernel driver is probably needed to reference the bank measurement method correctly
+   # it appears that the temp sensor registers are off by one with the default driver
+   # so SYSTIN is offset incorrectly and referenced as one of the AUXTIN values.
+   
+   # I have interpeted the NCT spec as 
+   # ID    NCTSpec   Other Notes
+   # temp1 SYSTIN    Incorrect driver mapping of AUXTIN0
+   # temp2 CPUTIN    Actual CPU temperature verified physically
+   # temp3 AUXTIN0   Actual motherboard temperature verified physically
+   # temp4 AUXTIN1   Unused
+   # temp5 AUXTIN2   Unused
+   # temp6 AUXTIN3   Unused
+
+   ignore  temp1 
+
+   label   temp2          "CPU"
+   set     temp2_max      85
+   set     temp2_max_hyst 50
+   #set     temp2_beep     1
+
+   label   temp3          "MB"
+   set     temp3_max      75
+   set     temp3_max_hyst 50
+   #set     temp3_beep     1
+   
+   ignore  temp4
+   
+   ignore  temp5
+   
+   ignore  temp6
+   
+   label   temp7          "CPU_PECI"
+   set     temp7_max      85
+   set     temp7_max_hyst 50
+   #set     temp7_beep     1
+   
+   ignore  temp8
+   ignore  temp9
+   ignore  temp10
+
+   # fans
+   # thankfully, fan PWM counters seem to function out of the box.
+   # labels are based on the board documentation
+
+   label   fan1           "Chassis_Fan_1/Pump"
+   set     fan1_min       300
+   set     fan1_beep      1
+   
+   label   fan2           "CPU_Fan_1"
+   set     fan2_min       600
+   set     fan2_beep      1
+   
+   label   fan5           "Chassis_Fan_2"
+   set     fan5_min       300
+   set     fan5_beep      1
+
+   # these are not on the mainboard
+   ignore  fan3
+   ignore  fan4
+
+   # misc
+   #intrusion0 is actually available. When disabled in BIOS it returns OK
+   ignore intrusion1


### PR DESCRIPTION
This is a configuration for an ASRock Z390M ITX/ac motherboard. Sensor data is cross referenced from ASRock's A-Tuning application data, as well as physical testing of the board. Some fan rpm parameters are still up to the user to adjust as necessary for their specific implementation.