### PR TITLE
Add config for MSI X570-A Pro

### DIFF
--- a/configs/MSI/X570-A-Pro.conf
+++ b/configs/MSI/X570-A-Pro.conf
@@ -1,0 +1,105 @@
+# lm-sensors configuration for MSI X570-A Pro - MS-7C37
+# Unverified/unknown values marked with a "?"
+
+chip "nct6797-*"
+	label fan1 "Pump"
+	label fan2 "CPU Fan"
+	label fan3 "System Fan 1"
+	label fan4 "System Fan 2"
+	label fan5 "System Fan 3"
+	label fan6 "System Fan 4"
+
+	label fan7 "PCH Fan"
+	set fan7_min 0
+
+	label in0  "VCore"
+	set in0_min 0.40
+	set in0_max 1.55
+
+	label in1  "+5V"
+	compute in1 @ * 5, @ / 5
+	set in1_min 5 * 0.95
+	set in1_max 5 * 1.15
+
+	label in2 "+3.3V (AVCC)"
+	set in2_min 3.3 * 0.95
+	set in2_max 3.3 * 1.15
+
+	label in3  "+3.3V (3VCC)"
+	set in3_min 3.3 * 0.95
+	set in3_max 3.3 * 1.15
+
+	label in4  "+12V"
+	compute in4 @ * 12 , @ / 12
+	set in4_min 12 * 0.95
+	set in4_max 12 * 1.05
+
+	# in5 - Unknown
+	set in5_min 0.15 * 0.95
+	set in5_max 0.15 * 1.15
+
+	label in6  "CHIP CLDO" #?
+	compute in6 @ * 2, @ / 2
+	set in6_min 1.2 * 0.95
+	set in6_max 1.2 * 1.15
+
+	label in7 "3VSB"
+	set in7_min 3.3 * 0.95
+	set in7_max 3.3 * 1.15
+
+	label in8 "VBAT"
+	set in8_min 3.3 * 0.95
+	set in8_max 3.3 * 1.15
+
+	label in9  "VTT"
+	set in9_min 1.8 * 0.95
+	set in9_max 1.8 * 1.15
+
+	ignore in10 # Always 0V
+
+	label in11 "DRAM VREF" #?
+	set in11_min 0.12
+	set in11_max 1.235
+
+	label in12 "CPU NB/SoC"
+	set in12_min 1.0
+	set in12_max 1.2
+
+	label in13 "DIMM"
+	compute in13 @ * 2 , @ / 2
+	set in13_min 0.8
+	set in13_max 1.5
+
+	label in14 "5VSB" #?
+	compute in14 ((768 / 330) + 1) * @, @ / ((768 / 330) + 1)
+	set in14_min 5 * 0.95
+	set in14_max 5 * 1.15
+
+	label temp1 "System"
+	
+	# Keeping default label because I'm really not sure about it
+	# label temp2 "M.2 1" #?
+	
+	label temp3 "VR MOS"
+
+	# Always reports -128°C
+	ignore temp4
+
+	label temp5 "Chipset"
+
+	# Always reports -1°C
+	ignore temp6
+
+	label temp7 "CPU (Tctl)"
+
+	# Always report 0°C	
+	ignore temp8
+	ignore temp9
+	ignore temp10
+
+	label intrusion0 "Chassis intrusion"
+	compute intrusion0 (intrusion0_alarm - 1) * -1, (@ - 1) * -1
+
+	# No header present on the board
+	ignore intrusion1
+


### PR DESCRIPTION
I obtained most values by comparison with other boards with similar Nuvoton/Winbond SuperIOs, with values from BIOS and HWiNFO64 + SIW for Windows.

Labels closely match those found in the firmware setup UI.

Values marked with `#?` I'd say I'm 70% sure they're correct but not 100%.

I'm particularly not sure about `temp2` (which reports as `CPUTIN` if label is commented out) because the temperature doesn't seem to be affected by the CPU temperature. It most likely is `M.2 1` since the values are close to the ones in the firmware UI (and still different from the temperature reported by the NVMe SSD, but at least it's consistent). HWiNFO64 reports it as `CPU (PECI)` but it doesn't look right to me. I left it commented out, I'll see if I can figure it out by visually inspecting the board.

Values for `PCIE 1` also reported by BIOS and SIW seem to not show up at all.