### PR TITLE
Update TUF-GAMING-X570-PLUS.conf

### DIFF
--- a/configs/Asus/TUF-GAMING-X570-PLUS.conf
+++ b/configs/Asus/TUF-GAMING-X570-PLUS.conf
@@ -52,7 +52,6 @@ label fan5 "CHA_FAN1"
     set fan5_min 1000
 
 # Always show zeros
-ignore temp8
 ignore temp9
 ignore temp10
 


### PR DESCRIPTION
Starting with kernel 5.7.11 temp8 has become a valid sensor: "PECI Agent 0 Calibration"