### PR TITLE
silence stderr of sensors -u

### DIFF
--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -61,10 +61,8 @@ void print_chip_raw(const sensors_chip_name *name)
 			if (sub->flags & SENSORS_MODE_R) {
 				if ((err = sensors_get_value(name, sub->number,
 							     &val)))
-					fprintf(stderr, "ERROR: Can't get "
-						"value of subfeature %s: %s\n",
-						sub->name,
-						sensors_strerror(err));
+					printf("  %s: ERR: $s\n", sub->name,
+					       sensors_strerror(err));
 				else {
 					if (fahrenheit)
 						val = deg_ctof(val);


### PR DESCRIPTION
Normal output of sensors and sensors -u differs also in the amount of potential error messages sent to stderr.
The -u option is meant for post processing, but it more often sends errors to stderr.

I suggest to keep error messages inline with the normal output on stdout, so that it is better visible with what chip the error happened.
And most important simplify parsing.
