### PR TITLE
Add sensors config file for Lenovo ThinkPad X260

### DIFF
--- a/configs/Lenovo/ThinkPad-X260-i5.conf
+++ b/configs/Lenovo/ThinkPad-X260-i5.conf
@@ -1,0 +1,31 @@
+chip "iwlwifi_1-*"
+    label temp1 "WiFi Card"
+
+chip "thinkpad-isa-*"
+    label fan1 "Fan Speed"
+    label temp1 "Case (near CPU)"
+
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+    ignore temp8
+
+chip "BAT0-*"
+    label in0 "Internal Battery"
+
+chip "BAT1-*"
+    label in0 "Removable Battery"
+
+chip "coretemp-isa-*"
+    label temp1 "CPU Package"
+    label temp2 "CPU Core 0"
+    label temp3 "CPU Core 1"
+
+chip "pch_skylake-*"
+    label temp1 "Chipset/Southbridge"
+
+chip "acpitz-acpi-*"
+    label temp1 "Case (ACPI Thermal Zone)"


### PR DESCRIPTION
This PR adds a configuration for a Lenovo ThinkPad X260 with an Intel i5 processor. It may also work fine for other flavors of the X260 laptops but I cannot test this.