### PR TITLE
sensord: Add support of emergency alarm

### DIFF
--- a/prog/sensord/chips.c
+++ b/prog/sensord/chips.c
@@ -221,7 +221,9 @@ static void fillChipTemperature(FeatureDescriptor *temperature,
 	if ((sf = sensors_get_subfeature(name, feature,
 					 SENSORS_SUBFEATURE_TEMP_ALARM)) ||
 	    (sf = sensors_get_subfeature(name, feature,
-					 SENSORS_SUBFEATURE_TEMP_MAX_ALARM))) {
+					 SENSORS_SUBFEATURE_TEMP_MAX_ALARM)) ||
+	    (sf = sensors_get_subfeature(name, feature,
+					 SENSORS_SUBFEATURE_TEMP_EMERGENCY_ALARM))) {
 		temperature->alarmNumber = sf->number;
 	} else {
 		temperature->alarmNumber = -1;


### PR DESCRIPTION
Currently sensord supports temp alarm and temp max alarm.
Add support of emergency alarm to allow alerting when an
emergency alarm is signalled.

Signed-off-by: Amit Cohen <amcohen@nvidia.com>