### PR TITLE
Add Biostar A960D+V2 config

### DIFF
--- a/configs/Biostar/A960D+V2.conf
+++ b/configs/Biostar/A960D+V2.conf
@@ -1,0 +1,51 @@
+# Configuration file contributed by Leandro Nini.
+
+
+# libsensors configuration file
+# -----------------------------
+#
+# This is a first attempt at a custom configuration file for the Biostar A960D+V2.
+# This custom configuration file should be copied to /etc/sensors.d/Biostar-A960D+V2.conf.
+#
+# Custom configuration files for some specific mainboards can be found at
+# https://github.com/lm-sensors/lm-sensors/tree/master/configs
+
+# READ THE MAN PAGE DOCUMENTATION OF 'sensors.conf' FOR MORE
+# COMPLETE INFORMATION. ie:
+
+# man sensors.conf
+
+chip "it8728-*"
+
+# All labels set to match Biostar A960D+V2 BIOS displayed labels. See
+# the 'PC Health' screen in the BIOS.
+
+# Voltage settings
+
+    label in0 "CPU"
+    label in1 "DDR"
+    label in2 "+12V"
+    label in3 "+5V"
+    ignore in4
+    ignore in5
+    label in6 "Chip" 
+
+    compute in2 6.0*@,@/6.0
+    compute in3 ((15/10)+1)*@ , @/((15/10)+1)
+
+# Fan settings
+
+    label fan1 "CPU Fan"
+    label fan2 "Sys1 Fan"
+    ignore fan3
+
+# Temperature sensor settings
+
+    label temp1 "CPU Temp"
+    label temp3 "Sys Temp"
+
+# temp2 is not identified
+    ignore temp2
+
+    ignore intrusion0
+


### PR DESCRIPTION
As the subject says, sensors output seems to match the BIOS display.