### PR TITLE
Add B450m Pro4 conf

### DIFF
--- a/configs/ASRock/B450m_Pro4.conf
+++ b/configs/ASRock/B450m_Pro4.conf
@@ -1,0 +1,93 @@
+# ASRock B450m Pro4
+# 2020
+#
+# dmi: board_name:   B450m Pro4
+# dmi: board_vendor: ASRock
+# dmi: bios_version: P4.30
+# cpu: AMD Ryzen 5 1600 Six-Core Processor
+# driver: nct6775
+
+chip "k10temp-pci-00c3"
+    label temp1 "CPU Core Temp"
+
+chip "nct6779-isa-0290"
+    label   in0     "Vcore"
+    compute in0     @*2, @/2
+    set     in0_min 0.30
+    set     in0_max 1.45
+
+    label   in12     "+5.0V"
+    compute in12     @*3, @/3
+    set     in12_min 5.00 * 0.90
+    set     in12_max 5.00 * 1.10
+
+    label   in2     "AVCC"
+    set     in2_min 3.30 * 0.90
+    set     in2_max 3.30 * 1.10
+
+    label   in3     "+3.3V"
+    set     in3_min 3.30 * 0.90
+    set     in3_max 3.30 * 1.10
+
+    label   in4     "+12.0V"
+    compute in4     @*(66/10), @/(66/10)
+    set     in4_min 12.0 * 0.95
+    set     in4_max 12.0 * 1.05
+
+    label   in5      "VDDCR_SOC"
+    set     in5_min  0.80
+    set     in5_max  1.20
+
+    label   in6     "DRAMV"
+    set     in6_min 1.10 # DDR4 Underclocking
+    set     in6_max 1.50 # DDR4 Intel XMP2.0 recommended max safe voltage
+
+    label   in7     "3VSB"
+    set     in7_min 3.30 * 0.90
+    set     in7_max 3.30 * 1.10
+
+    label   in8 "VBAT"
+    set     in8_min 3.00 * 0.90
+    set     in8_max 3.30 * 1.10
+
+    ignore in9
+
+    label   in10     "VDDP"
+    set     in10_min 0.90
+    set     in10_max 1.20
+
+    label   in11     "+1.05V"
+    set     in11_min 1.05 * 0.9
+    set     in11_max 1.05 * 1.1
+
+    ignore in1
+    ignore in13
+
+    label   in14     "+1.8V"
+    set     in14_min 1.8 * 0.9
+    set     in14_max 1.8 * 1.1
+
+    label  fan1     "Chassis Fan 3"
+    label  fan2     "CPU Fan 1"
+    set    fan2_min 400
+    ignore fan3
+    label  fan4     "Chassis Fan 1"
+    label  fan5     "Chassis Fan 2"
+
+    label  temp1   "Motherboard Temp"
+    set temp1_max      55.0
+    set temp1_max_hyst 50.0
+
+    label  temp7   "CPU Temp"
+
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp8
+    ignore temp9
+    ignore temp10
+
+    ignore intrusion0
+    ignore intrusion1

--- a/configs/ASRock/B450m_Pro4.conf
+++ b/configs/ASRock/B450m_Pro4.conf
@@ -39,6 +39,7 @@ chip "nct6779-isa-0290"
     set     in5_max  1.20
 
     label   in6     "DRAMV"
+    compute in6     @*4, @/4
     set     in6_min 1.10 # DDR4 Underclocking
     set     in6_max 1.50 # DDR4 Intel XMP2.0 recommended max safe voltage
 


### PR DESCRIPTION
```
nct6779-isa-0290
Adapter: ISA adapter
Vcore:              1.25 V  (min =  +0.00 V, max =  +3.49 V)
AVCC:               3.38 V  (min =  +2.98 V, max =  +3.63 V)
+3.3V:              3.36 V  (min =  +2.98 V, max =  +3.63 V)
+12.0V:            12.20 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
VDDCR_SOC:          1.05 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
DRAMV:            1.38 V (min =  +0.00 V, max =  +0.00 V)  ALARM
3VSB:               3.41 V  (min =  +2.98 V, max =  +3.63 V)
VBAT:               3.26 V  (min =  +2.70 V, max =  +3.63 V)
VDDP:             248.00 mV (min =  +0.00 V, max =  +0.00 V)  ALARM
+1.05V:             1.06 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
+5.0V:              5.06 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
+1.8V:              1.78 V  (min =  +0.00 V, max =  +0.00 V)  ALARM
Chassis Fan 3:    1409 RPM  (min =    0 RPM)
CPU Fan 1:        2824 RPM  (min =    0 RPM)
Chassis Fan 1:       0 RPM  (min =    0 RPM)
Chassis Fan 2:       0 RPM  (min =    0 RPM)
Motherboard Temp:  +40.0°C  (high =  +0.0°C, hyst =  +0.0°C)  ALARM  sensor = thermistor
CPU Temp:          +72.5°C  
beep_enable:      disabled
```
Based off AB350_Pro4.conf