### PR TITLE
sensors-detect: Add support for NCT6687D.

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2289,6 +2289,13 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x0b,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Nuvoton NCT6687D eSIO",
+		driver => "nct6683",
+		devid => 0xD590,
+		devid_mask => 0xFFF0,
+		logdev => 0x0b,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Nuvoton NCT6102D/NCT6104D/NCT6106D Super IO Sensors",
 		driver => "nct6775",
 		devid => 0xC450,


### PR DESCRIPTION
This is a companion to https://marc.info/?l=lm-sensors&m=160681657707434&w=2.

Tested on an MSI MAG B550M MORTAR motherboard.