### PR TITLE
Update pwmconfig

### DIFF
--- a/prog/pwm/pwmconfig
+++ b/prog/pwm/pwmconfig
@@ -284,7 +284,7 @@ echo 'Found the following fan sensors:'
 for i in $FAN
 do
 	S=$(cat $i)
-	if [ "$S" = "0" -o "$S" = "-1" ]
+	if [ "$S" = "0" -o "$S" = "-1" -o "$S" = ""  ]
 	then
 		echo "   $i     current speed: 0 ... skipping!"
 	else


### PR DESCRIPTION
If sensor doesn't return any value (in my case it happen when fan got broken - look below) whole script gets messed up. "cut" latter in the script assume there are more values in $GOODFAN then there are really and "cut -d' ' -f$count" doesn't return proper value.

root@yaro-desktop2:/sys/class/hwmon# cat hwmon0/fan1_input 
cat: hwmon0/fan1_input: Bad argument
root@yaro-desktop2:/sys/class/hwmon#