### PR TITLE
sensors: Handle json trailing ',' when no features are listed

### DIFF
--- a/prog/sensors/main.c
+++ b/prog/sensors/main.c
@@ -178,11 +178,19 @@ static void do_a_json_print(const sensors_chip_name *name)
 {
 	printf("   \"%s\":{\n", sprintf_chip_name(name));
 	if (!hide_adapter) {
+		int a = 0;
 		const char *adap = sensors_get_adapter_name(&name->bus);
-		if (adap)
-			printf("      \"Adapter\": \"%s\",\n", adap);
-		else
+		if (adap) {
+			printf("      \"Adapter\": \"%s\"", adap);
+			/* only print trailing ',' if there are features to list */
+			if (sensors_get_features(name, &a) != NULL) {
+				printf(",\n");
+			} else {
+				printf("\n");
+			}
+		} else {
 			fprintf(stderr, "Can't get adapter name\n");
+		}
 	}
 	print_chip_json(name);
 	printf("   }");


### PR DESCRIPTION
The json format requires that the last entry of a dictionary does not
have a trailing ','. To avoid generating invalid json output, check that
there are features to list before emitting the trailing ','.

This issue is present when a chip exists but all its sensors are
ignored:
```
{
    "example-device" : {
      "Adapter": "example adapter",
    }
}
```

The corrected output is:
```
{
    "example-device" : {
      "Adapter": "example adapter"
    }
}
```