### PR TITLE
Add config for MSI B550-A Pro

### DIFF
--- a/configs/MSI/MS-7C56-B550-A-Pro.conf
+++ b/configs/MSI/MS-7C56-B550-A-Pro.conf
@@ -1,0 +1,53 @@
+# lm-sensors configuration for the MSI B550-A PRO motherboard
+#
+# Manufacturer: Micro-Star International (MSI) 
+# Product Name: B550-A PRO
+# Code Name: MS-7C56
+# Version: Ver 1.1
+# Super I/O: NCT6683R
+# UEFI BIOS tested: A.63 03/03/2021
+#
+# Recommended drivers: k10temp, nct6683
+
+chip "nct6687-isa-0a20"
+
+	#Voltage
+	label in0 "System +12V"
+	compute in0 @*12,@/12
+
+	label in1 "System +5V"
+	compute in1 @*5,@/5
+
+	label in2 "CPU NB/SOC"
+
+	label in3 "DRAM"
+	compute in3 @*2,@/2
+
+	label in4 "CPU VCore"
+	label in5 "Chipset"
+	ignore in6
+	label in7 "CPU VDDP"
+	label in8 "System +3.3V"
+	label in9 "CPU 1P8"
+
+	#Fan
+	label fan1 "CPU Fan"	
+	label fan2 "Pump Fan"
+	label fan3 "System Fan #1"
+	label fan4 "System Fan #2"
+	label fan5 "System Fan #3"
+	label fan6 "System Fan #4"
+	label fan7 "System Fan #5"
+	label fan8 "System Fan #6"
+	ignore fan9
+	ignore fan10
+
+	#Temp
+	label temp1 "CPU"
+	label temp2 "System"
+	label temp3 "VRM MOS"
+	label temp4 "PCM"
+	label temp5 "CPU Socket"
+	label temp6 "PCIe x1"
+	label temp7 "M2_1"
+


### PR DESCRIPTION
This is basically a copy of the settings from MS-7C91 aka MSI-MAG B550 TOMAHAWK.