### PR TITLE
Add special behavior for fans that only allow a small number of speed steps

### DIFF
--- a/prog/pwm/fancontrol
+++ b/prog/pwm/fancontrol
@@ -42,6 +42,7 @@ PIDFILE="/var/run/fancontrol.pid"
 
 #DEBUG=1
 MAX=255
+LAST_CHANGE=
 
 function LoadConfig
 {
@@ -64,6 +65,7 @@ function LoadConfig
 	MINSTART=$(grep -E '^MINSTART=.*$' $1 | sed -e 's/MINSTART=//g')
 	MINSTOP=$(grep -E '^MINSTOP=.*$' $1 | sed -e 's/MINSTOP=//g')
 	# optional settings:
+	DELAY=$(grep -E '^DELAY=.*$' $1 | sed -e 's/DELAY=//g')
 	FCFANS=$(grep -E '^FCFANS=.*$' $1 | sed -e 's/FCFANS=//g')
 	MINPWM=$(grep -E '^MINPWM=.*$' $1 | sed -e 's/MINPWM=//g')
 	MAXPWM=$(grep -E '^MAXPWM=.*$' $1 | sed -e 's/MAXPWM=//g')
@@ -86,6 +88,7 @@ function LoadConfig
 	echo
 	echo "Common settings:"
 	echo "  INTERVAL=$INTERVAL"
+	echo "  DELAY=$DELAY"
 
 	let fcvcount=0
 	for fcv in $FCTEMPS
@@ -518,6 +521,52 @@ function restorefans()
 trap 'restorefans 0' SIGQUIT SIGTERM
 trap 'restorefans 1' SIGHUP SIGINT
 
+function checkCurrentPWMValues
+{
+	let fcvcount=0
+	while (( $fcvcount < ${#AFCPWM[@]} ))
+	do
+		pwmo=${AFCPWM[$fcvcount]}
+		read pwmpval < ${pwmo}
+		if [ $? -ne 0 ]
+		then
+			echo "Error reading PWM value from $DIR/$pwmo"
+			break;
+		fi
+		[ -n "$DEBUG" ] && echo "[$fcvcount] Read PWM value $pwmpval from $pwmo"
+		LASTPWMVAL[$fcvcount]=$pwmpval
+		let fcvcount=$fcvcount+1
+	done
+}
+
+function checkChangedPWMValues
+{
+	if [ -z "$DELAY" ]
+	then
+		return # use step delays only if DELAY is set
+	fi
+	
+	let fcvcount=0
+	while (( $fcvcount < ${#AFCPWM[@]} ))
+	do
+		pwmo=${AFCPWM[$fcvcount]}
+		read pwmpval < ${pwmo}
+		if [ $? -ne 0 ]
+		then
+			echo "Error reading PWM value from $DIR/$pwmo"
+			break;
+		fi
+		if [ "$pwmpval" -ne "${LASTPWMVAL[$fcvcount]}" ]; then
+			[ -n "$DEBUG" ] && echo "[$fcvcount] Updated pwmval to $pwmpval (was ${LASTPWMVAL[$fcvcount]})"
+			LAST_CHANGE=$(date +'%s')
+			LASTPWMVAL[$fcvcount]=$pwmpval
+		else
+			[ -n "$DEBUG" ] && echo "[$fcvcount] No update to pwmval: $pwmpval == ${LASTPWMVAL[$fcvcount]}"
+		fi
+		let fcvcount=$fcvcount+1
+	done
+}
+
 # main function
 function UpdateFanSpeeds
 {
@@ -525,6 +574,13 @@ function UpdateFanSpeeds
 	local pwmo tsens fan mint maxt minsa minso minpwm maxpwm
 	local tval tlastval pwmpval fanval min_fanval one_fan one_fanval
 	local -i pwmval
+
+	if [ -n "$LAST_CHANGE" ] && [ "$LAST_CHANGE" -ge $(( $(date +'%s') - $DELAY )) ]; then
+		[ -n "$DEBUG" ] && echo "Delaying fan speed update until $(date +%T --date @$(($LAST_CHANGE + $DELAY)))"
+		return
+	else
+		[ -n "$DEBUG" ] && echo "Not delaying run because '$LAST_CHANGE' < '$(date +'%s')'"
+	fi
 
 	let fcvcount=0
 	while (( $fcvcount < ${#AFCPWM[@]} )) # go through all pwm outputs
@@ -669,8 +725,14 @@ echo 'Starting automatic fan control...'
 # main loop calling the main function at specified intervals
 while true
 do
+	let wakeup=$(date +'%s')+$INTERVAL
+	checkCurrentPWMValues
 	UpdateFanSpeeds
+	while (( $(date +'%s') < $wakeup ))
+	do
+		checkChangedPWMValues
 	# Sleep while still handling signals
-	sleep $INTERVAL &
+		sleep 1 &
 	wait
+	done
 done

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -38,6 +38,10 @@ variables available for changing \fBfancontrol\fP's behaviour:
 This variable defines at which interval in seconds the main loop of
 \fBfancontrol\fP will be executed
 .TP
+.B DELAY
+When set, this variable enables "stepped fans" behaviour (see below) with
+the step delay set to the number of seconds specified by this variable.
+.TP
 .B DEVPATH
 Maps hwmon class devices to physical devices. This lets \fBfancontrol\fP
 check that the configuration file is still up-to-date.
@@ -120,6 +124,23 @@ changes, but only if the temp is between MINTEMP and MAXTEMP. After that, the
 new values are written to the PWM outputs. Currently the speed increases
 linearly with rising temperature. This way you won't hear your fans most
 of the time at best.
+
+.SH STEPPED FANS BEHAVIOR
+
+Some devices that export PWM outputs only support a limited set of speeds, such
+that when \fBfancontrol\fP calculats a PWM speed value, the value will be
+normalized to one of the supported speed values that can be read back from the
+PWM device. When used with such a device, the \fBfancontrol\fP might cause the
+fan to flactutate between low speed and high speed back and forth every
+INTERVAL, which might be a jarring user experience. On the other hand,
+increasing INTERVAL will result in a undesired increase in response time to
+temperatures spikes.
+
+The stepped fans behavior may be enabled by setting the DELAY varaible. When
+set \fBfancontrol\fP will monitor the real PWM value for changes, and when a
+speed step is observed, \fBfancontrol\fP will suspend monitoring for the
+specified time - letting the system stick with the new fan speed for a while
+before checking if it needs to step back.
 
 .SH SEE ALSO
 pwmconfig(8), sensors(1).


### PR DESCRIPTION
I'm using fancontrol successfully in several systems, but on my Dell Precision laptop the fans only have 3 speeds - off, low and high, so that when fancontrol manages the fan speeds, and tries to calculate a good PWM value, it will either set low speed or - when the temperature is high enough - trigger the high speed mode for INTERVAL seconds before setting low speed again (as the high speed mode is very good at cooling). With INTERVAL set to a low number (the default is 10?) this becomes really annoying really fast with the fan oscillating between low noise and high noise every 10 seconds.

This PR adds a special "stepped fans" behavior (as documented in the man page) where an additional delay can be set that will trigger a pause in monitoring after fancontrol sees a step change in the PWM read value.

The main problem with implementing this feature is that the new "real" PWM value can only be read back from the PWM device after a few seconds (about 2 seconds on my system), so I had to change the main loop to not sleep the entire INTERVAL but instead poll the PWM input value in 1 second intervals.

This is just an idea (though I'm happy with how it works on my machine), and I would love it if this is accepted as is, but I expect everyone will have comments and I'd love to have a discussion and update this PR with whatever changes are needed to get something like this behavior merged.