### PR TITLE
fancontrol, pwmconfig: Allow read-only pwm*_enable

### DIFF
--- a/prog/pwm/fancontrol
+++ b/prog/pwm/fancontrol
@@ -489,8 +489,8 @@ function pwmenable()
 			PWM_ORIG_STATE[${1}]=$PWM_ORIG
 		fi
 		# enable manual control by fancontrol
-		echo 1 > $ENABLE 2> /dev/null
-		if [ $? -ne 0 ]
+		(echo 1 > $ENABLE) 2> /dev/null
+		if [ "$(cat $ENABLE)" -ne 1 ]
 		then
 			return 1
 		fi

--- a/prog/pwm/pwmconfig
+++ b/prog/pwm/pwmconfig
@@ -214,14 +214,12 @@ function pwmenable()
 {
 	local ENABLE=${1}_enable
 
-	if [ -w $ENABLE ]
+	(echo 1 > $ENABLE) 2>/dev/null
+	if [ "$(cat $ENABLE)" -ne 1 ]
 	then
-		echo 1 2>/dev/null > $ENABLE
-		if [ $? -ne 0 ]
-		then
-			return 1
-		fi
+		return 1
 	fi
+
 	echo $MAX > $1
 }
 


### PR DESCRIPTION
In my driver I want to use `pwm*_enable` attribute to indicate whether a fan was detected by the device.
The device is NZXT RGB & Fan Controller/"Smart Device v2", the driver is here: https://github.com/amezin/nzxt-rgb-fan-controller-dkms

The device has a dedicated command that runs fan detection. If fan was not detected - the device won't control its speed. The only available control mode is manual (fixed speed). So I thought I could use a read-only `pwm*_enable`, returning `0` if fan was not detected and `1` if it was detected. However, `pwmconfig` and `fancontrol` refuse to work with read-only `pwm*_enable` (but it looks like they were intended to work - there are a few writability tests)

https://github.com/lm-sensors/lm-sensors/issues/343