### PR TITLE
Do not run lm_sensors.service in virtual environments

### DIFF
--- a/prog/init/lm_sensors.service
+++ b/prog/init/lm_sensors.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Initialize hardware monitoring sensors
+ConditionVirtualization=no
 
 [Service]
 EnvironmentFile=/etc/sysconfig/lm_sensors


### PR DESCRIPTION
It makes sense to make systemd service lm_sensors.service be enabled out of the box
in a GNU/Linux distro, but it fails in virtual environments because there are no sensors there.
I think that the vast majority of virtual environments do not have any sensors.

Fedora/Red Hat patch sensors to not fail if there are no sensors [1].

[1] https://src.fedoraproject.org/rpms/lm_sensors/blob/f35/f/lm_sensors-3.6.0-allow_no_sensors.patch