### PR TITLE
configs: Add ASUS M5A97 motherboard

### DIFF
--- a/configs/Asus/M5A97.conf
+++ b/configs/Asus/M5A97.conf
@@ -1,0 +1,48 @@
+# lm-sensors configuration fo rthe ASUS M5A97
+#
+# Manufacturer: ASUSTeK COMPUTER INC.
+# Product Name: M5A97\
+# Version: Rev 1.xx
+# Super I/O: IT8721F
+# Bios Version: 1605
+
+chip "it8721-*"
+	label in0 "12V Voltage"
+	label in1 "5V Voltage"
+	label in2 "VCORE Voltage"
+	label in3 "3.3 Voltage"
+	ignore in4 # Not available in BIOS
+	label in5 "VDDA2.5 Voltage"
+	ignore in6 # Not available in BIOS
+	ignore in7 # Not available in BIOS
+	label in8 "Vbat Voltage"
+
+	compute in0 @ * (515 / 120), @ / (515 / 120)
+	compute in1 @ * (215 / 120), @ / (215 / 120)
+
+	set in0_min 12 * 0.95
+	set in0_max 12 * 1.05
+	set in1_min 5 * 0.95
+	set in1_max 5 * 1.05
+	set in2_min 1.075
+	set in2_max 1.875
+	set in3_min 3.3 * 0.95
+	set in3_max 3.3 * 1.05
+	set in5_min 2.2
+	set in5_max 2.8
+
+	label fan1 "CPU FAN Speed"
+	label fan2 "CHASSIS FAN 1 Speed"
+	label fan3 "CHASSIS FAN 2 Speed"
+	ignore fan4 # No connector present
+	label fan5 "POWER FAN Speed"
+
+	set fan1_min 100
+	set fan2_min 100
+	set fan3_min 100
+	set fan4_min 100
+	set fan5_min 100
+
+	label temp1 "CPU Temperature"
+	label temp2 "MB Temperature"
+	ignore temp3 # Not available in BIOS


### PR DESCRIPTION
This patch adds support for the ASUS M5A97 (not R2.0, the original)
motherboard.

The labels map exactly to the BIOS labels for consistency sake.

The CPU and VDDA voltage limits are the absolute minimum and maximum
values the motherboard regulators can supply. Users can always fine-tune
these to their own preference if so desired.

Found values where compared against bios values. The bios does have some
extra settable voltages, but those are not affecting the ignore sensors.
Maybe the Asus software has names/formulas for them, but as this is
Windows only software, not usable.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>