### PR TITLE
Support nct6106 chip and add config for Supermicro A2SAP

### DIFF
--- a/configs/SuperMicro/A2SAP.conf
+++ b/configs/SuperMicro/A2SAP.conf
@@ -1,0 +1,3 @@
+chip "nct6106-isa-*"
+
+    label in5 "Vdimm"

--- a/etc/sensors.conf.default
+++ b/etc/sensors.conf.default
@@ -311,6 +311,17 @@ chip "w83627thf-*"
 #    set in8_max  3.0 * 1.10
 
 
+chip "nct6106-isa-*"
+
+    label in0 "Vcore"
+    label in2 "AVCC"
+    label in3 "+3.3V"
+    label in6 "3VSB"
+    label in7 "Vbat"
+
+    compute in6 @*2, @/2
+
+
 chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" \
      "nct6779-*" "nct6791-*" "nct6795-*" "nct6796-*"
 


### PR DESCRIPTION
The specification for nct6106 can be found here:
https://www.nuvoton.com/export/resource-files/NCT6102D_NCT6106D_Datasheet_V1_0.pdf
Chapter 8.5.2.1 (page 73 of pdf)

The Supermicro A2SAP uses the nct6106 and reports Vdimm at VIN2 (which is "in6")