### PR TITLE
pwmconfig: Deal with relative paths for the config file.

### DIFF
--- a/prog/pwm/pwmconfig
+++ b/prog/pwm/pwmconfig
@@ -31,6 +31,7 @@
 
 LM_VERSION='3.6.0+git'
 PIDFILE="/var/run/fancontrol.pid"
+USERDIR=$(pwd)
 
 if [ -f "$PIDFILE" ]
 then
@@ -613,6 +614,10 @@ function AskPath()
 	if [ "$FCCONFIG" = "" ]
 	then
 		FCCONFIG="/etc/fancontrol"
+	fi
+	if [ ${FCCONFIG::1} != "/" ]
+	then
+		FCCONFIG=$(readlink -f $USERDIR/$FCCONFIG)
 	fi
 }
 

--- a/prog/pwm/pwmconfig
+++ b/prog/pwm/pwmconfig
@@ -617,7 +617,7 @@ function AskPath()
 	fi
 	if [ ${FCCONFIG::1} != "/" ]
 	then
-		FCCONFIG=$(readlink -f $USERDIR/$FCCONFIG)
+		FCCONFIG=$(readlink -f "$USERDIR"/"$FCCONFIG")
 	fi
 }
 
@@ -668,7 +668,7 @@ function LoadConfig()
 	fi
 }
 
-LoadConfig $FCCONFIG
+LoadConfig "$FCCONFIG"
 
 # $1 = pwm value below which the fan is stopped
 function TestMinStart()
@@ -820,8 +820,8 @@ function SaveConfig()
 	echo "MINSTOP=$MINSTOP" >>$tmpfile
 	[ -n "$MINPWM" ] && echo "MINPWM=$MINPWM" >>$tmpfile
 	[ -n "$MAXPWM" ] && echo "MAXPWM=$MAXPWM" >>$tmpfile
-	mv $tmpfile $FCCONFIG
-	chmod +r $FCCONFIG
+	mv $tmpfile "$FCCONFIG"
+	chmod +r "$FCCONFIG"
 	#check if file was written correctly
 	echo 'Configuration saved'
 }


### PR DESCRIPTION
The script changes working directory during operation, so when the user is asked about the path to the config file, she will unlikely realize that relative paths wont work.
There is no check that the config was successfully written so this results in a silent loss of the configuration file.
This change caches the starting directory and prepends it to the config path if it does not begin with a '/', allowing for relative paths to be used safely.