### PR TITLE
Added support for the ASRock A320M HDV R4.0

### DIFF
--- a/configs/ASRock/A320M_HDVR4.0.conf
+++ b/configs/ASRock/A320M_HDVR4.0.conf
@@ -1,0 +1,88 @@
+# ASRock A320M-HDV R4.0
+# 2022, contributed by Merlin Schumacher
+# dmi: board_name: A320M-HDV R4.0
+# dmi: board_vendor: ASRock 
+# dmi: bios_version: P7.10
+
+chip "amdgpu-pci-0600"
+  ignore in0
+  ignore in1
+  label temp1 "GPU Temp" 
+
+chip "k10temp-pci-00c3"
+  label temp1 "CPU Core Temp"
+  label temp2 "CPU TCtrl Temp"
+
+chip "nct6793-isa-0290"
+  label in0 "Vcore"
+    compute in0     @*2, @/2  
+    set     in0_min 0.16
+    set     in0_max 1.46
+ 
+  label in2 "AVCC"
+    set     in2_min 3.30 * 0.90
+    set     in2_max 3.30 * 1.10
+
+  label   in3     "+3.3V"
+    set     in3_min 3.30 * 0.90
+    set     in3_max 3.30 * 1.10
+
+  label   in7     "3VSB"
+    set     in7_min 3.30 * 0.90
+    set     in7_max 3.30 * 1.10
+
+  label   in8 "VBAT"
+    set     in8_min 3.00 * 0.90
+    set     in8_max 3.30 * 1.10
+
+  label   in9 "+12V"
+    compute in9 @*(53/8), @/(53/8)
+    set     in9_min 12 * 0.90
+    set     in9_max 12 * 1.10
+
+  label   in12     "+12V"
+  #((56+10)/10)
+    compute in12 @*6.6, @/6.6
+    set     in12_min 12 * 0.95
+    set     in12_max 12 * 1.05
+
+  label   in13     "+5V"
+  compute in13 @*(24/8), @/(24/8)
+    set     in13_min 5 * 0.90
+    set     in13_max 5 * 1.10
+ 
+# these have non-zero input, but are unknown
+  ignore  in1
+  ignore  in4
+  ignore  in5
+  ignore  in6
+  ignore  in10
+  ignore  in11
+  ignore  in12
+  ignore  in14
+ 
+  label temp2 "CPU_TEMP"
+    set temp2_max      75
+    set temp2_max_hyst 70
+  label temp3 "MB_TEMP"
+    set     temp3_max 55
+    set     temp3_max_hyst 50
+  label temp7 "CPU_DIE_TEMP"
+  ignore SYSTIN
+
+# these have a nonsensical input
+  ignore temp1 
+  ignore temp4 
+  ignore temp5 
+  ignore temp6 
+  ignore temp8 
+  ignore temp9 
+  ignore temp10 
+
+  label fan1 "CHASSIS_FAN1"
+  label fan2 "CPU_FAN"
+  label fan5 "CHASSIS_FAN2"
+# these have a nonsensical input
+  ignore fan3
+  ignore fan4
+


### PR DESCRIPTION
This adds support for ASRocks A320M HDV R4.0. The values have been validated against the config files in ASRocks OEM Sensor tool