### PR TITLE
feat: add MSI B660M MORTAR DDR4 (MS-7D42) configuration

### DIFF
--- a/configs/MSI/MS-7D42.conf
+++ b/configs/MSI/MS-7D42.conf
@@ -1,0 +1,46 @@
+# MS-7D42 config
+# 
+# DMI:
+# System Information
+#         Manufacturer: Micro-Star International Co., Ltd.
+#         Product Name: MS-7D42
+#         Version: 1.0
+#
+# Base Board Information
+#         Manufacturer: Micro-Star International Co., Ltd.
+#         Product Name: MAG B660M MORTAR WIFI DDR4 (MS-7D42)
+#         Version: 1.0
+#
+# BIOS Information
+#         Vendor: American Megatrends International, LLC.
+#         Version: 1.40
+#
+# drivers:
+# coretemp nct6683
+#
+# driver issue:
+# set options force=1 to enable support for unknown vendors.
+# https://github.com/torvalds/linux/blob/master/drivers/hwmon/nct6683.c#L41
+#
+# fix driver issue:
+# $ echo "options nct6683 force=1" | sudo tee /etc/modprobe.d/nct6683.conf
+# $ sudo sensors-detect --auto
+#
+#
+# tested on B660M MORTAR DDR4 (MS-7D42)
+# Configuration file contributed by Jerry Y. Chen <chen at jyny.dev>
+
+chip "nct6687-*"
+
+		# fan define
+		# https://download.msi.com/archive/mnu_exe/mb/MAGB660MMORTARWIFIDDR4_MAGB660MMORTARDDR4.pdf
+    label fan1 CPU_FAN1
+    label fan2 PUMP_FAN1
+    label fan3 SYS_FAN1
+    label fan4 SYS_FAN2
+    ignore fan5
+    ignore fan6
+    ignore fan7
+    ignore fan8
+    ignore fan9
+    ignore fan10


### PR DESCRIPTION
This PR adds a configuration for MSI B660M MORTAR DDR4 (MS-7D42).
The configuration is tested on the motherboard and works fine.
