### PR TITLE
Makefile: drop usage of 'which'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ manhtml:
 
 # Flex and Bison
 %.c: %.y
-	@if ! which $(BISON) 2> /dev/null ; then \
+	@if ! command -v $(BISON) 2> /dev/null ; then \
 		echo "Please install $(BISON), then run \"make clean\" and try again" ; \
 		false ; \
 	fi
@@ -280,7 +280,7 @@ FLEX_FLAGS := -Psensors_yy -t -Cfe -8
 endif
 
 %.c: %.l
-	@if ! which $(FLEX) 2> /dev/null ; then \
+	@if ! command -v $(FLEX) 2> /dev/null ; then \
 		echo "Please install $(FLEX), then run \"make clean\" and try again" ; \
 		false ; \
 	fi


### PR DESCRIPTION
`which` is an external command which isn't required by POSIX.

Debian and other distributions (like Gentoo!) are looking
to drop it from their base set of packages.

Switch to `command -v` which should always work instead.

Signed-off-by: Sam James <sam@gentoo.org>