### PR TITLE
ZSH completion for sensors and sensors-detect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ ETCDIR := /etc
 # library files (both static and shared) will be installed.
 LIBDIR := $(PREFIX)/lib
 
+# You should not need to change this. It is the directory into which the
+# data files will be installed.
+DATADIR := $(PREFIX)/share
+
+# You should not need to change this. It is the directory into which the
+# ZSH completion files will be installed.
+ZSHCOMPDIR := $(DATADIR)/zsh/site-functions
+
 EXLDFLAGS := -Wl,-rpath,$(LIBDIR)
 
 # You should not need to change this. It is the directory into which the

--- a/prog/detect/Module.mk
+++ b/prog/detect/Module.mk
@@ -24,6 +24,7 @@ PROGDETECTDIR := $(MODULE_DIR)
 
 PROGDETECTMAN8DIR := $(MANDIR)/man8
 PROGDETECTMAN8FILES := $(MODULE_DIR)/sensors-detect.8
+PROGDETECTZSHCOMPFILES := $(MODULE_DIR)/_sensors-detect
 
 # Regrettably, even 'simply expanded variables' will not put their currently
 # defined value verbatim into the command-list of rules...
@@ -31,19 +32,22 @@ PROGDETECTSBININSTALL := $(MODULE_DIR)/sensors-detect
 
 REMOVEDETECTBIN := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(SBINDIR)/%,$(PROGDETECTSBININSTALL))
 REMOVEDETECTMAN := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(PROGDETECTMAN8DIR)/%,$(PROGDETECTMAN8FILES))
+REMOVEDETECTZSH := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(ZSHCOMPDIR)/%,$(PROGDETECTZSHCOMPFILES))
 
 all-prog-detect:
 user :: all-prog-detect
 
 install-prog-detect: all-prog-detect
-	$(MKDIR) $(DESTDIR)$(SBINDIR) $(DESTDIR)$(PROGDETECTMAN8DIR)
+	$(MKDIR) $(DESTDIR)$(SBINDIR) $(DESTDIR)$(PROGDETECTMAN8DIR) $(DESTDIR)$(ZSHCOMPDIR)
 	$(INSTALL) -m 755 $(PROGDETECTSBININSTALL) $(DESTDIR)$(SBINDIR)
 	$(INSTALL) -m 644 $(PROGDETECTMAN8FILES) $(DESTDIR)$(PROGDETECTMAN8DIR)
+	$(INSTALL) -m 644 $(PROGDETECTZSHCOMPFILES) $(DESTDIR)$(ZSHCOMPDIR)
 user_install :: install-prog-detect
 
 user_uninstall::
 	$(RM) $(REMOVEDETECTBIN)
 	$(RM) $(REMOVEDETECTMAN)
+	$(RM) $(REMOVEDETECTZSH)
 
 clean-prog-detect:
 clean :: clean-prog-detect

--- a/prog/detect/_sensors-detect
+++ b/prog/detect/_sensors-detect
@@ -1,0 +1,10 @@
+#compdef sensors-detect
+
+typeset -a args
+
+args=(
+    '--auto[run in automatic mode, assuming default answers to all questions (may not be safe)]'
+    '--stat[display i2c address statistics]'
+)
+
+_arguments $args

--- a/prog/sensors/Module.mk
+++ b/prog/sensors/Module.mk
@@ -24,6 +24,7 @@ PROGSENSORSDIR := $(MODULE_DIR)
 
 PROGSENSORSMAN1DIR := $(MANDIR)/man1
 PROGSENSORSMAN1FILES := $(MODULE_DIR)/sensors.1
+PROGSENSORSZSHCOMPFILES := $(MODULE_DIR)/_sensors
 
 # Regrettably, even 'simply expanded variables' will not put their currently
 # defined value verbatim into the command-list of rules...
@@ -36,6 +37,7 @@ INCLUDEFILES += $(PROGSENSORSSOURCES:.c=.rd)
 
 REMOVESENSORSBIN := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(BINDIR)/%,$(PROGSENSORSTARGETS))
 REMOVESENSORSMAN := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(PROGSENSORSMAN1DIR)/%,$(PROGSENSORSMAN1FILES))
+REMOVESENSORSZSH := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(ZSHCOMPDIR)/%,$(PROGSENSORSZSHCOMPFILES))
 
 LIBICONV := $(shell if /sbin/ldconfig -p | grep -q '/libiconv\.so$$' ; then echo \-liconv; else echo; fi)
 
@@ -46,14 +48,16 @@ all-prog-sensors: $(PROGSENSORSTARGETS)
 user :: all-prog-sensors
 
 install-prog-sensors: all-prog-sensors
-	$(MKDIR) $(DESTDIR)$(BINDIR) $(DESTDIR)$(PROGSENSORSMAN1DIR)
+	$(MKDIR) $(DESTDIR)$(BINDIR) $(DESTDIR)$(PROGSENSORSMAN1DIR) $(DESTDIR)$(ZSHCOMPDIR)
 	$(INSTALL) -m 755 $(PROGSENSORSTARGETS) $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 644 $(PROGSENSORSMAN1FILES) $(DESTDIR)$(PROGSENSORSMAN1DIR)
+	$(INSTALL) -m 644 $(PROGSENSORSZSHCOMPFILES) $(DESTDIR)$(ZSHCOMPDIR)
 user_install :: install-prog-sensors
 
 user_uninstall::
 	$(RM) $(REMOVESENSORSBIN)
 	$(RM) $(REMOVESENSORSMAN)
+	$(RM) $(REMOVESENSORSZSH)
 
 clean-prog-sensors:
 	$(RM) $(PROGSENSORSDIR)/*.rd $(PROGSENSORSDIR)/*.ro 

--- a/prog/sensors/_sensors
+++ b/prog/sensors/_sensors
@@ -1,0 +1,29 @@
+#compdef sensors
+
+# List of adapters. This depends on jq to parse the json output.
+_sensors_adapaters() {
+    declare -a adapters
+    eval set -A adapters "$(sensors -j | jq -r 'keys|@sh')" 
+    _values adapter $adapters
+}
+
+_sensors() {
+    typeset -a args
+
+    args=(
+        '--bus-list[generate bus statements for sensors.conf]'
+        '--no-adapter[do not show adapter for each chip]'
+        '-A[do not show adapter for each chip]'
+        '-j[json output]'
+        '-u[raw output]'
+        '(--allow-no-sensors -n)'{--allow-no-sensors,-n}'[do not fail if no sensors found]'
+        '(--config-file -c)'{--config-file,-c}'[specify a config file]:file:_files'
+        '(--fahrenheit -f)'{--fahrenheit,-f}'[show temperatures in degrees fahrenheit]'
+        '(--set -s)'{--set,-s}'[execute `set'\'' statements (root only)]'
+        '(-)'{--help,-h}'[display help text]'
+        '(-)'{--version,-v}'[display the program version]'
+        '*:chip:_sensors_adapaters'
+    )
+
+    _arguments $args
+}


### PR DESCRIPTION
This PR adds ZSH completion for sensors and sensors-detect.

* I did consider adding completion for the other commands, but for the most part it didn't seem to make sense or be widely used commands. I could revisit that if you want.
* I have not added bash completion as I don't use bash, nor do I have any knowledge of how to write such completion files.
* To be able to complete the adapter names for `sensors` the easiest way was to parse the json output using `jq` to get extract the keys from that array. This is not ideal as it adds another (optional) dependency. An alternative would be to introduce another flag to the `sensors` command to just list the adapter names (preferably newline separated).
