### PR TITLE
Add support for dev_name formatted like "a000000.wifi"

### DIFF
--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -663,8 +663,9 @@ static int classify_device(const char *dev_name,
 	if ((!subsys || !strcmp(subsys, "platform") ||
 			!strcmp(subsys, "of_platform"))) {
 		/* must be new ISA (platform driver) */
-		if (sscanf(dev_name, "%*[a-zA-Z0-9_]%*1[.:]%d", &entry->chip.addr) != 1)
-			entry->chip.addr = 0;
+		if (sscanf(dev_name, "%*[a-zA-Z0-9_]%*1[.:]%d", &entry->chip.addr) == 1);
+		else if (sscanf(dev_name, "%x.%*s", &entry->chip.addr) == 1);
+		else entry->chip.addr = 0;
 		entry->chip.bus.type = SENSORS_BUS_TYPE_ISA;
 		entry->chip.bus.nr = 0;
 	} else if (subsys && !strcmp(subsys, "acpi")) {


### PR DESCRIPTION
openwrt/packages#10623
Some devices use device name formatted like "a000000.wifi" and this format is currently not supported, if not, it has the potential to create sensors with the same name, this would confuse collectd and cause it to spamming errors and openwrt's luci-app-statistics will not function properly.