### PR TITLE
Add Fujitsu D3402-B1 config

### DIFF
--- a/configs/FujitsuTechnologySolutions/D3402-B1.conf
+++ b/configs/FujitsuTechnologySolutions/D3402-B1.conf
@@ -1,0 +1,43 @@
+# Fujitsu Technology Solutions D3402-B1, "Teutates"-Chip
+# Contributed by Armin Wolf <W_Armin@gmx.de>
+
+chip "ftsteutates-*"
+
+# Temperatures
+    label temp1 "PECI"
+    label temp2 "Graphics"
+    label temp3 "Ambient"
+    label temp4 "Core"
+    label temp5 "Memory"
+    label temp6 "PCH"
+    label temp7 "Teutates"
+    ignore temp8
+    ignore temp9
+    ignore temp10
+    ignore temp11
+    ignore temp12
+    ignore temp13
+    ignore temp14
+    ignore temp15
+    ignore temp16
+
+# Fans
+    label fan1 "CPU"
+    label fan2 "SYS"
+    label fan3 "OEM"
+    label fan4 "PSU"
+    ignore fan5
+    ignore fan6
+    ignore fan7
+    ignore fan8
+
+# Voltages
+    label in1 "VCC 3.3V"
+    label in2 "3.3V AUX"
+    label in3 "V_IN (12V)"
+    label in4 "VBAT 3.0V"
+
+    compute in1   @*1.1, @/1.1
+    compute in2   @*1.1, @/1.1
+    compute in3   @*3.9, @/3.9
+    compute in4   @*1.0, @/1.0


### PR DESCRIPTION
Create config for the Fujitsu D3402-B1 motherboard. The config was provided by github user @rcmcronny, see #421 for details.

Signed-off-by: Armin Wolf <W_Armin@gmx.de>