### PR TITLE
Add support for "inverted mode" PWM to fancontrol

### DIFF
--- a/prog/pwm/fancontrol
+++ b/prog/pwm/fancontrol
@@ -118,30 +118,79 @@ function LoadConfig
 			echo "MINTEMP must be less than MAXTEMP" >&2
 			exit 1
 		fi
-		if [ "${AFCMAXPWM[$fcvcount]}" -gt 255 ]
-		then
-			echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
-			echo "MAXPWM must be at most 255" >&2
-			exit 1
-		fi
-		if [ "${AFCMINSTOP[$fcvcount]}" -ge "${AFCMAXPWM[$fcvcount]}" ]
-		then
-			echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
-			echo "MINSTOP must be less than MAXPWM" >&2
-			exit 1
-		fi
-		if [ "${AFCMINSTOP[$fcvcount]}" -lt "${AFCMINPWM[$fcvcount]}" ]
-		then
-			echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
-			echo "MINSTOP must be greater than or equal to MINPWM" >&2
-			exit 1
-		fi
-		if [ "${AFCMINPWM[$fcvcount]}" -lt 0 ]
-		then
-			echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
-			echo "MINPWM must be at least 0" >&2
-			exit 1
-		fi
+
+        if [ "${AFCMINPWM[$fvcount]}" -lt "${AFCMAXPWM[$fvcount]}" ]; then
+           # Normal drive:
+           # PWM value 0   -> Fan not spinning
+           # PWM value 255 -> Fan spinning at full speed
+
+		   if [ "${AFCMAXPWM[$fcvcount]}" -gt $MAX ]
+		   then
+			   echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			   echo "For normal drive MAXPWM must be at most $MAX" >&2
+		       exit 1
+		   fi
+
+		   if [ "${AFCMINSTOP[$fcvcount]}" -ge "${AFCMAXPWM[$fcvcount]}" ]
+		   then
+			   echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			   echo "For normal drive MINSTOP must be less than MAXPWM" >&2
+			   exit 1
+		   fi
+
+		   if [ "${AFCMINSTOP[$fcvcount]}" -lt "${AFCMINPWM[$fcvcount]}" ]
+		   then
+			   echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			   echo "For normal drive MINSTOP must be greater than or equal to MINPWM" >&2
+			   exit 1
+		   fi
+
+		   if [ "${AFCMINPWM[$fcvcount]}" -lt 0 ]
+		   then
+			   echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			   echo "For normal drive MINPWM must be at least 0" >&2
+			   exit 1
+		   fi
+
+        elif [ "${AFCMINPWM[$fvcount]}" -gt "${AFCMAXPWM[$fvcount]}" ]; then
+            # Inverted drive:
+            # PWM value 255   -> Fan not spinning
+            # PWM value 0 -> Fan spinning at full speed
+
+		    if [ "${AFCMINPWM[$fcvcount]}" -gt $MAX ]
+		    then
+			    echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			    echo "For inverted drive MINPWM must be at most $MAX" >&2
+		        exit 1
+		    fi
+
+		    if [ "${AFCMINSTOP[$fcvcount]}" -lt "${AFCMAXPWM[$fcvcount]}" ]
+		    then
+			    echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			    echo "For inverted drive MINSTOP must be larger than MAXPWM" >&2
+			    exit 1
+		    fi
+
+		    if [ "${AFCMINSTOP[$fcvcount]}" -ge "${AFCMINPWM[$fcvcount]}" ]
+		    then
+			    echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			    echo "For inverted drive MINSTOP must be less than MINPWM" >&2
+			    exit 1
+		    fi
+
+		    if [ "${AFCMAXPWM[$fcvcount]}" -lt 0 ]
+		    then
+			    echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+			    echo "For inverted drive MAXPWM must be at least 0" >&2
+			    exit 1
+		    fi
+
+        else
+            echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2
+            echo "MINPWM and MAXPWM cannot be equal" >&2
+            exit 1
+        fi
+
 		if [ "${AFCAVERAGE[$fcvcount]}" -lt 1 ]
 		then
 			echo "Error in configuration file (${AFCPWM[$fcvcount]}):" >&2


### PR DESCRIPTION


I have a https://wikidevi.wi-cat.ru/Netgear_ReadyNAS_3138 NAS device and I wanted to use fancontrol to adjust the speed of 3 fans built into the chassis. These fans are driven by PWM outputs from the IT8732F on the mainboard with the quirk that values written to the /sys files need to be inverted. That is value 255 stops the fan completely, value 0 drives it at full speed. I will call this "inverted mode" from now on as opposed to "normal mode" where 0 is fan stops and 255 means fan at full speed.

In order to use fancontrol I built the following configuration file:

```
INTERVAL=1

MINTEMP=hwmon0/pwm1=40
MAXTEMP=hwmon0/pwm1=70

MINSTART=hwmon0/pwm1=170
MINSTOP=hwmon0/pwm1=190

MINPWM=hwmon0/pwm1=255
MAXPWM=hwmon0/pwm1=0

FCTEMPS=hwmon0/pwm1=hwmon0/temp3_input

DEVPATH=hwmon0=devices/platform/it87.2608
DEVNAME=hwmon0=it8732
```

In the current code this config file fails the config validity checks:

```
[nix-shell:~]# fancontrol fancontrol.conf 
Loading configuration from fancontrol.conf ...

Common settings:
  INTERVAL=1
Error in configuration file (hwmon0/pwm1):
MINSTOP must be less than MAXPWM
```

After studying the fancontrol code I concluded that the fan speed update algorithm will work regardless of whether the PWM output operates in "normal mode" or "inverted mode" and the only thing that needs to be updated are the various configuration sanity checks. Therefore I developed an updated fancontrol script that has the config validity checks split into two codepaths based on the relationship of MAXPWM and MINPWM.

I am sending the new fancontrol script as a pull request for your consideration. Please note that this is my first pull request to lm-sensors and all suggestions are welcome :).
