### PR TITLE
New configuration for Netgear RN3138 NAS

### DIFF
--- a/configs/Netgear/RN3138.conf
+++ b/configs/Netgear/RN3138.conf
@@ -1,0 +1,95 @@
+# Configuration for the Netgear RN3138 / RNR-4B NAS 
+#
+# Chassis identification labels:
+# NETGEAR Advanced Network Storage Model No. RNR-4B
+# Model Name: RN3138
+#
+# Identification from DMI:
+# dmidecode -s system-manufacturer: NETGEAR
+# dmidecode -s system-product-name: ReadyNAS 3138
+# dmidecode -s system-version: 03/05/2015 ReadyNAS 3130 V0.9
+# dmidecode -s system-sku-number: RN3138
+#
+# BIOS:
+#
+# dmidecode -s bios-version: 5.6.5
+# dmidecode -s bios-release-date: 03/05/2015
+# 
+# Monitoring chipset
+# Chip: IT8732F
+# Driver: it87
+# 
+
+chip "it8732-isa-*"
+
+  ### Voltage sense
+  ### The labels and equations reverse-engineered by measuring voltages on the board, finding
+  ### voltage dividers and comparing the voltages to what is reported in the BIOS.
+  ###
+  ### No datasheet for IT8732F has been discovered so its unknown what the recommended wiring is.
+  ### VIN[0-7] pinout has been taken from IT8782F datasheet it seems to match.
+
+  # These go straight to the IT8732F, confirmed in BIOS Setup
+  label in0 "Vcore"
+  label in1 "DDR 1.5V"
+
+  # These looks to be a second 3.3V input with a 10k/20k divider
+  label in2 "+3.3V_2"
+  compute in2 @*((10/20)+1), @/((10/20)+1)
+
+  # in3 is labeled as +3.3V by the it87 driver, supposedly wired internally inside the chip
+  # The reported value is halved
+  compute in3 @*2, @/2
+
+  # Resistors could not be reverse engineered from the board, a simple scaling factor was calculated
+  label in4 "+12V"
+  compute in4 @*6.59, @/6.59
+
+  # in5 and in6 are unknown, one of them is most likely the +5V rail but the +5V divider voltage 
+  # and the measured voltages do not match.
+  # Specifically, the +5V divider outputs 1.86V but in5 reads 1.44V and in6 reads 2.78V
+
+  # in7 is labeled as 3VSB by the it87 driver
+  # The reported value is halved
+  compute in7 @*2, @/2
+
+  # in8 is labeled as Vbat by the it87 driver, probably wired internally inside the chip
+  # The reported value looks to be nonsense as it reports 1.6V without a battery inserted.
+  # Ignore for now
+  ignore in8
+
+  # Establish a 10% tolerance range for alarms
+  set in0_min 1.0 * 0.95
+  set in0_max 1.0 * 1.05
+  set in1_min 1.5 * 0.95
+  set in1_max 1.5 * 1.05
+  set in2_min 3.3 * 0.95
+  set in2_max 3.3 * 1.05
+  set in3_min 3.3 * 0.95
+  set in3_max 3.3 * 1.05
+  set in4_min 12 * 0.95
+  set in4_max 12 * 1.05
+  
+  set in7_min 3.3 * 0.95
+  set in7_max 3.3 * 1.05
+  
+
+  ### Temperatures
+  ### The BIOS reports only one temperature sensors and labels it "System temperature3", it's obviously temp3
+  ### Other temp inputs are not wired
+  ignore temp1
+  ignore temp2
+  label temp3 "System temperature"
+
+  set temp3_max 50
+
+  
+  ###
+  ### System contains only chassis fans, confirmed in BIOS
+  ### The RPM reported for PWM value of 128 is around 5500 RPM
+  label fan1 "Chassis fan 1"
+  label fan2 "Chassis fan 2"
+  label fan3 "Chassis fan 3"
+
+  # Not wired
+  ignore intrusion0

--- a/configs/Netgear/RN3138.conf
+++ b/configs/Netgear/RN3138.conf
@@ -2,6 +2,7 @@
 #
 # Chassis identification labels:
 # NETGEAR Advanced Network Storage Model No. RNR-4B
+# NETGEAR RN3184E-100NES
 # Model Name: RN3138
 #
 # Identification from DMI:


### PR DESCRIPTION
This is a new configuration file for the Netgear RN3138 NAS.

Plain sensors output:

```
coretemp-isa-0000
Adapter: ISA adapter
Core 0:       +36.0°C  (high = +98.0°C, crit = +98.0°C)
Core 1:       +36.0°C  (high = +98.0°C, crit = +98.0°C)
Core 2:       +35.0°C  (high = +98.0°C, crit = +98.0°C)
Core 3:       +36.0°C  (high = +98.0°C, crit = +98.0°C)

it8732-isa-0a30
Adapter: ISA adapter
in0:         992.00 mV (min =  +0.95 V, max =  +1.05 V)
in1:           1.50 V  (min =  +1.43 V, max =  +1.57 V)
in2:           2.19 V  (min =  +2.09 V, max =  +2.31 V)
+3.3V:         1.66 V  (min =  +1.57 V, max =  +1.73 V)
in4:           1.82 V  (min =  +1.73 V, max =  +1.91 V)
in5:           1.41 V  (min =  +1.91 V, max =  +0.34 V)  ALARM
in6:           2.78 V  (min =  +2.08 V, max =  +1.15 V)  ALARM
3VSB:          1.65 V  (min =  +1.57 V, max =  +1.73 V)
Vbat:          1.62 V  
fan1:           0 RPM  (min =   18 RPM)  ALARM
fan2:           0 RPM  (min =   11 RPM)  ALARM
fan3:           0 RPM  (min =   16 RPM)  ALARM
temp1:        -70.0°C  (low  = -61.0°C, high = -115.0°C)  ALARM  sensor = disabled
temp2:        -70.0°C  (low  = -95.0°C, high = +100.0°C)  sensor = thermal diode
temp3:        +37.0°C  (low  = -33.0°C, high = +50.0°C)  sensor = thermal diode
intrusion0:  ALARM
```

Output with config file:

```
[nix-shell:~]# sensors -c sensors.conf 
coretemp-isa-0000
Adapter: ISA adapter
Core 0:       +36.0°C  (high = +98.0°C, crit = +98.0°C)
Core 1:       +36.0°C  (high = +98.0°C, crit = +98.0°C)
Core 2:       +35.0°C  (high = +98.0°C, crit = +98.0°C)
Core 3:       +36.0°C  (high = +98.0°C, crit = +98.0°C)

it8732-isa-0a30
Adapter: ISA adapter
Vcore:              981.00 mV (min =  +0.95 V, max =  +1.05 V)
DDR 1.5V:             1.50 V  (min =  +1.43 V, max =  +1.57 V)
+3.3V_2:              3.29 V  (min =  +3.14 V, max =  +3.47 V)
+3.3V:                3.31 V  (min =  +3.14 V, max =  +3.47 V)
+12V:                11.99 V  (min = +11.42 V, max = +12.57 V)
in5:                  1.41 V  (min =  +1.91 V, max =  +0.34 V)  ALARM
in6:                  2.78 V  (min =  +2.08 V, max =  +1.15 V)  ALARM
3VSB:                 3.29 V  (min =  +3.14 V, max =  +3.47 V)
Chassis fan 1:         0 RPM  (min =   18 RPM)  ALARM
Chassis fan 2:         0 RPM  (min =   11 RPM)  ALARM
Chassis fan 3:         0 RPM  (min =   16 RPM)  ALARM
System temperature:  +37.0°C  (low  = -33.0°C, high = +50.0°C)  sensor = thermal diode
```
