### PR TITLE
Fix sensors.conf syntax documentation

### DIFF
--- a/lib/sensors.conf.5
+++ b/lib/sensors.conf.5
@@ -465,7 +465,7 @@ or
 
 .RS
 bus
-.B NAME NAME NAME
+.B NAME NAME
 .sp 0
 chip
 .B NAME\-LIST


### PR DESCRIPTION
Removes an extra third NAME in the bus syntax description to match the Bus statement documentation and implementation.