### PR TITLE
fancontrol: Executable commands as temp sensors.

### DIFF
--- a/prog/pwm/fancontrol
+++ b/prog/pwm/fancontrol
@@ -297,10 +297,19 @@ function CheckFiles
 	while (( $fcvcount < ${#AFCTEMP[@]} )) # go through all temp inputs
 	do
 		tsen=${AFCTEMP[$fcvcount]}
-		if [ ! -r $tsen ]
+		if [ ${tsen::1} == "!" ]
 		then
-			echo "Error: file $tsen doesn't exist or isn't readable" >&2
-			outdated=1
+			if ! [ -x ${tsen:1} ]
+			then
+				echo "Error: file ${tsen:1} doesn't exist or isn't executable" >&2
+				outdated=1
+			fi
+		else
+			if ! [ -r $tsen ]
+			then
+				echo "Error: file $tsen doesn't exist or isn't readable" >&2
+				outdated=1
+			fi
 		fi
 		let fcvcount=$fcvcount+1
 	done
@@ -541,7 +550,12 @@ function UpdateFanSpeeds
 		maxpwm=${AFCMAXPWM[$fcvcount]}
 		avg=${AFCAVERAGE[$fcvcount]}
 
-		read tlastval < ${tsens}
+		if [ ${tsens::1} == "!" ]
+		then
+			tlastval="$(${tsens:1})"
+		else
+			read tlastval < ${tsens}
+		fi
 		if [ $? -ne 0 ]
 		then
 			echo "Error reading temperature from $DIR/$tsens"

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -49,7 +49,9 @@ the configuration file is still up-to-date.
 .B FCTEMPS
 Maps PWM outputs to temperature sensors so \fBfancontrol\fP knows which
 temperature sensors should be used for calculation of new values for
-the corresponding PWM outputs.
+the corresponding PWM outputs. A prefix of ! can be used to execute a
+command as a temperature sensor.
+
 .TP
 .B FCFANS
 Records the association between a PWM output and a fan input.


### PR DESCRIPTION
This small change to fancontrol will treat temperature sensors that start with a `!` as commands to execute and read the output of.

This lets users integrate fancontrol with scripts that calculate or measure temperature in arbitrary ways.