### PR TITLE
New configuration for Lenovo ThinkPad X120e

### DIFF
--- a/configs/Lenovo/ThinkPad-X120e.conf
+++ b/configs/Lenovo/ThinkPad-X120e.conf
@@ -1,0 +1,34 @@
+chip "thinkpad-isa-0000"
+	# Fan speed is erroneously reported in revolutions per clock tick
+	# rather than in RPM. This formula recalculates fan speed, while
+	# also avoiding devision by zero when the fan is idle.
+	# 1350000 states for the number of 22.5 kHz clock ticks in 1 minute.
+	compute	fan1	1350000 * (1 - ^-@) / (@ + ^-@), 1350000 * (1 - ^-@) / (@ + ^-@)
+	compute	fan2	1350000 * (1 - ^-@) / (@ + ^-@), 1350000 * (1 - ^-@) / (@ + ^-@)
+	label	fan1	"Fan speed"
+	label	fan2	"Fan speed"
+	label	temp1	"CPU temperature"
+	ignore	temp2
+	label	temp3	"GPU temperature"
+	ignore	temp4
+	ignore	temp5
+	ignore	temp6
+	label	temp7	"CMOS battery temperature"
+	ignore	temp8
+
+chip "acpitz-acpi-0"
+	label	temp1	"CPU temperature"
+
+chip "k10temp-pci-00c3"
+	label	temp1	"CPU temperature"
+
+chip "radeon-pci-0008"
+	label	in0		"GPU voltage"
+	label	temp1	"GPU temperature"
+
+chip "BAT1-acpi-0"
+	label	in0	"Battery voltage"
+
+chip "drivetemp-*"
+	label	temp1	"Storage temperature"
+


### PR DESCRIPTION
Lack of configuration for Lenovo ThinkPad X120e laptop leads to sensors being displayed in a raw form. Add a configuration for Lenovo ThinkPad X120e so that the sensors are displayed in a more user-friendly manner.