### PR TITLE
sensors+sensors-detect: Add support for NCT6799D

### DIFF
--- a/etc/sensors.conf.default
+++ b/etc/sensors.conf.default
@@ -312,7 +312,7 @@ chip "w83627thf-*"
 
 
 chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" \
-     "nct6779-*" "nct6791-*" "nct6795-*" "nct6796-*"
+     "nct6779-*" "nct6791-*" "nct6795-*" "nct6796-*" "nct6799-*"
 
     label in0 "Vcore"
     label in2 "AVCC"

--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2373,6 +2373,13 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x0b,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Nuvoton NCT6799D Super IO Sensors",
+		driver => "nct6775",
+		devid => 0xD800,
+		devid_mask => 0xFFF8,
+		logdev => 0x0b,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Fintek F71805F/FG Super IO Sensors",
 		driver => "f71805f",
 		devid => 0x0406,


### PR DESCRIPTION
Also adds support for NCT6796D-S. Tested on ASRock B650E PG Riptide WiFi with the NCT6796D-S sensor.
Output with 3.6.0:
```
Some Super I/O chips contain embedded sensors. We have to write to
standard I/O ports to probe them. This is usually safe.
Do you want to scan for Super I/O sensors? (YES/no): 
Probing for Super-I/O at 0x2e/0x2f
Trying family `National Semiconductor/ITE'...               No
Trying family `SMSC'...                                     No
Trying family `VIA/Winbond/Nuvoton/Fintek'...               Yes
Found unknown chip with ID 0xd802
    (logical device B has address 0x290, could be sensors)

```
And with this version:
```
Some Super I/O chips contain embedded sensors. We have to write to
standard I/O ports to probe them. This is usually safe.
Do you want to scan for Super I/O sensors? (YES/no): 
Probing for Super-I/O at 0x2e/0x2f
Trying family `National Semiconductor/ITE'...               No
Trying family `SMSC'...                                     No
Trying family `VIA/Winbond/Nuvoton/Fintek'...               Yes
Found `Nuvoton NCT6799D Super IO Sensors'                   Success!
    (address 0x290, driver `nct6775')
...
Now follows a summary of the probes I have just done.

Driver `nct6775':
  * ISA bus, address 0x290
    Chip `Nuvoton NCT6799D Super IO Sensors' (confidence: 9)
```
Support for these has been added to `hwmon` a while ago (https://marc.info/?l=linux-hwmon&m=167223542100841&w=2), and the `nct6775` driver works well.