### PR TITLE
rrd: adapt to constification of argv parameters

### DIFF
--- a/prog/sensord/rrd.c
+++ b/prog/sensord/rrd.c
@@ -299,7 +299,7 @@ int rrdInit(void)
 		argv[argc++] = rraBuff;
 		argv[argc] = NULL;
 
-		ret = rrd_create(argc, (char**) argv);
+		ret = rrd_create(argc, argv);
 		if (ret == -1) {
 			sensorLog(LOG_ERR, "Error creating RRD file: %s: %s",
 				  sensord_args.rrdFile, rrd_get_error());
@@ -455,7 +455,7 @@ int rrdUpdate(void)
 		const char *argv[] = {
 			"sensord", sensord_args.rrdFile, rrdBuff, NULL
 		};
-		if ((ret = rrd_update(3, (char **) /* WEAK */ argv))) {
+		if ((ret = rrd_update(3, /* WEAK */ argv))) {
 			sensorLog(LOG_ERR, "Error updating RRD file: %s: %s",
 				  sensord_args.rrdFile, rrd_get_error());
 		}


### PR DESCRIPTION
rrdtool has applied a patch to constify all argv parameters, which fixes incompatible pointer type errors with GCC 14.  This patch adapts accordingly, but would trigger similar errors against an rrdtool without that change.

https://github.com/oetiker/rrdtool-1.x/pull/1242

Making this compatible with both versions of rrdtool might take the addition of a configure test or the like.  Unfortunately, I don't have time to commit to that right now.