### PR TITLE
Add optional way of using Device Tree names in config file.

### DIFF
--- a/prog/pwm/fancontrol
+++ b/prog/pwm/fancontrol
@@ -43,6 +43,73 @@ PIDFILE="/var/run/fancontrol.pid"
 #DEBUG=1
 MAX=255
 
+# File to cache lookup of hwmon Device Tree names
+ofnamecache=$(mktemp -u).ofnamecache
+
+# Lookup hwmon name from Device Tree name
+function DoOFLookup
+{
+    ofname=$1
+    if [ -f "$ofnamecache" ]
+    then
+      hwmonname=$(awk -F = '/^'$ofname'=/ {print $2}' "$ofnamecache")
+    else
+      for hwmonofnode in /sys/class/hwmon/hwmon*/of_node
+      do
+        hwmonname=$(basename $(dirname $hwmonofnode))
+        ofname=$(basename $(readlink $hwmonofnode))
+        echo $ofname=$hwmonname >> $ofnamecache
+      done
+    fi
+    if [ -z "$hwmonname" ]
+    then
+        echo "Unknown DT name \"$ofname\"" >&2
+        exit -1
+    fi
+    echo $hwmonname
+}
+
+# Process given string for any name lookups required.
+function ProcessLookup
+{
+    str=$1
+    if [[ "$str" == "OF@"* ]]
+    then
+      ofname=${str/OF@/}
+      if [[ "$ofname" == *"/"* ]]
+      then
+        argument=${ofname/*\//}
+        ofname=${ofname/\/*/}
+        hwmonname=$(DoOFLookup $ofname)
+        str="$hwmonname/$argument"
+      else
+        str=$(DoOFLookup $ofname)
+      fi
+    fi
+    echo $str
+}
+
+# Process given array for any name lookups required.
+function ProcessArrayLookups
+{
+    array_sub=($@)
+    for n in $(seq 0 ${#array_sub[@]})
+    do
+      entry=${array_sub[$n]}
+      if [[ "$entry" == *"="* ]]
+      then
+        key=$(echo "$entry" | sed -e 's/=[^=]*$//')
+        value=$(echo "$entry" | sed -e 's/^[^=]*=//')
+        entry="$(ProcessLookup $key)=$(ProcessLookup $value)"
+      else
+        entry="$(ProcessLookup $entry)"
+      fi
+      array_sub[$n]=$entry
+    done
+    echo ${array_sub[@]}
+}
+
+
 function LoadConfig
 {
 	local fcvcount fcv
@@ -68,6 +135,21 @@ function LoadConfig
 	MINPWM=$(grep -E '^MINPWM=.*$' $1 | sed -e 's/MINPWM=//g')
 	MAXPWM=$(grep -E '^MAXPWM=.*$' $1 | sed -e 's/MAXPWM=//g')
 	AVERAGE=$(grep -E '^AVERAGE=.*$' $1 | sed -e 's/AVERAGE=//g')
+
+	# Do any name lookups done to avoid hwmon hardcoding and nondeterministic hwmon names
+	DEVPATH=$(ProcessArrayLookups ${DEVPATH[@]})
+	DEVNAME=$(ProcessArrayLookups ${DEVNAME[@]})
+	FCTEMPS=$(ProcessArrayLookups ${FCTEMPS[@]})
+	MINTEMP=$(ProcessArrayLookups ${MINTEMP[@]})
+	MAXTEMP=$(ProcessArrayLookups ${MAXTEMP[@]})
+	MINSTART=$(ProcessArrayLookups ${MINSTART[@]})
+	MINSTOP=$(ProcessArrayLookups ${MINSTOP[@]})
+	FCFANS=$(ProcessArrayLookups ${FCFANS[@]})
+	MINPWM=$(ProcessArrayLookups ${MINPWM[@]})
+	MAXPWM=$(ProcessArrayLookups ${MAXPWM[@]})
+	AVERAGE=$(ProcessArrayLookups ${AVERAGE[@]})
+
+	rm -f $(ofnamecache)
 
 	# Check whether all mandatory settings are set
 	if [[ -z ${INTERVAL} || -z ${FCTEMPS} || -z ${MINTEMP} || -z ${MAXTEMP} || -z ${MINSTART} || -z ${MINSTOP} ]]


### PR DESCRIPTION
Currently /etc/fancontrol has to use the hwmon names, which are nondeterministic. On a system with Device Tree, the simple and human readable way to avoid this is to use the Device Tree name. Other naming systems could be added to this code, but Device Tree is my user case.

So for example instead of:

  DEVPATH=hwmon0=devices/virtual/thermal/thermal_zone0 hwmon1=devices/platform/extra_fan hwmon2=devices/platform/case_fan hwmon4=devices/platform/soc/fe804000.i2c/i2c-1/1-004d
  DEVNAME=hwmon0=cpu_thermal hwmon1=pwmfan hwmon2=pwmfan hwmon4=lm75b
  FCTEMPS=hwmon2/pwm1=hwmon0/temp1_input hwmon1/pwm1=hwmon4/temp1_input
  MINTEMP=hwmon2/pwm1=20 hwmon1/pwm1=20
  MAXTEMP=hwmon2/pwm1=60 hwmon1/pwm1=60
  MINSTART=hwmon2/pwm1=50 hwmon1/pwm1=50
  MINSTOP=hwmon2/pwm1=30 hwmon1/pwm1=30
  FCFANS=hwmon2/pwm1= hwmon1/pwm1=
  MINPWM=hwmon2/pwm1=0 hwmon1/pwm1=0
  MAXPWM=hwmon2/pwm1=255 hwmon1/pwm1=255

I can then do:

  DEVPATH=hwmon0=devices/virtual/thermal/thermal_zone0 OF@extra_fan=devices/platform/extra_fan OF@case_fan=devices/platform/case_fan OF@backplane_84hp_temp_sens2=devices/platform/soc/fe804000.i2c/i2c-1/1-004d
  DEVNAME=hwmon0=cpu_thermal OF@extra_fan=pwmfan OF@case_fan=pwmfan OF@backplane_84hp_temp_sens2=lm75b
  FCTEMPS=OF@case_fan/pwm1=hwmon0/temp1_input OF@extra_fan/pwm1=OF@backplane_84hp_temp_sens2/temp1_input
  FCFANS=OF@case_fan/pwm1= OF@extra_fan/pwm1=
  MINTEMP=OF@case_fan/pwm1=20 OF@extra_fan/pwm1=20
  MAXTEMP=OF@case_fan/pwm1=60 OF@extra_fan/pwm1=60
  MINSTART=OF@case_fan/pwm1=50 OF@extra_fan/pwm1=50
  MINSTOP=OF@case_fan/pwm1=30 OF@extra_fan/pwm1=30
  MINPWM=OF@case_fan/pwm1=0 OF@extra_fan/pwm1=0
  MAXPWM=OF@case_fan/pwm1=255 OF@extra_fan/pwm1=255

( hwmon0 is always going to be hwmon0 as it's loaded first by some margin and has no name. The others are all loaded at the same time when the overlay is loaded.)

There are lots of people hacking round this but it just seams it's better solved upstream.