### PR TITLE
Ensure BUS_MODULES is Always Defined in sensors-detect Output

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -7452,8 +7452,7 @@ sub write_config
 # BUS_MODULES for any required bus driver module (for example for I2C or SPI).
 
 EOT
-		print SYSCONFIG "BUS_MODULES=\"", join(" ", @{$bus_modules}), "\"\n"
-			if @{$bus_modules};
+		print SYSCONFIG "BUS_MODULES=\"", join(" ", @{$bus_modules}), "\"\n";
 		print SYSCONFIG "HWMON_MODULES=\"", join(" ", @{$hwmon_modules}), "\"\n";
 		close(SYSCONFIG);
 


### PR DESCRIPTION
This pull request modifies the sensors-detect script to unconditionally define the BUS_MODULES variable in the generated /etc/sysconfig/lm_sensors file, even if BUS_MODULES is empty.

Previously, BUS_MODULES was only included in the configuration if it contained modules. This conditional behavior could lead to inconsistencies or errors in configurations that expect BUS_MODULES to be defined, regardless of its contents.

Removed the conditional check if @{$bus_modules}; to ensure BUS_MODULES is always defined.

Improves robustness by ensuring that downstream scripts and services that source lm_sensors configurations encounter a consistently defined BUS_MODULES variable.

Solves Issue: https://github.com/lm-sensors/lm-sensors/issues/473