### PR TITLE
libsensors: Add OEM info to ACPI power meter display.

### DIFF
--- a/lib/data.c
+++ b/lib/data.c
@@ -193,8 +193,14 @@ int sensors_snprintf_chip_name(char *str, size_t size,
 		return snprintf(str, size, "%s-virtual-%x", chip->prefix,
 				chip->addr);
 	case SENSORS_BUS_TYPE_ACPI:
-		return snprintf(str, size, "%s-acpi-%x", chip->prefix,
-				chip->addr);
+		if (!strcmp(chip->prefix, SENSORS_POWER_METER_NAME) &&
+		    chip->oem_info) {
+			return snprintf(str, size, "%s-acpi-%s", chip->prefix,
+					chip->oem_info);
+		} else {
+			return snprintf(str, size, "%s-acpi-%x", chip->prefix,
+					chip->addr);
+		}
 	case SENSORS_BUS_TYPE_HID:
 		return snprintf(str, size, "%s-hid-%hd-%x", chip->prefix,
 				chip->bus.nr, chip->addr);

--- a/lib/init.c
+++ b/lib/init.c
@@ -228,6 +228,7 @@ static void free_chip_name(sensors_chip_name *name)
 {
 	free(name->prefix);
 	free(name->path);
+	free(name->oem_info);
 }
 
 static void free_chip_features(sensors_chip_features *features)

--- a/lib/sensors.h
+++ b/lib/sensors.h
@@ -49,6 +49,8 @@
 #define SENSORS_BUS_NR_ANY		(-1)
 #define SENSORS_BUS_NR_IGNORE		(-2)
 
+#define SENSORS_POWER_METER_NAME	"power_meter"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -66,6 +68,7 @@ typedef struct sensors_chip_name {
 	sensors_bus_id bus;
 	int addr;
 	char *path;
+	char *oem_info;
 } sensors_chip_name;
 
 /* Load the configuration file and the detected chips list. If this

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -615,6 +615,17 @@ int sensors_init_sysfs(void)
 	return 1;
 }
 
+static void replace_space_underscore(char *str)
+{
+	unsigned int i;
+
+	for (i=0; i < strlen(str); i++) {
+		if (str[i] == ' ') {
+			str[i] = '_';
+		}
+	}
+}
+
 static int classify_device(const char *dev_name,
                            const char *subsys,
                            sensors_chip_features *entry)
@@ -623,6 +634,7 @@ static int classify_device(const char *dev_name,
 	char bus_path[NAME_MAX];
 	char *bus_attr;
 	int ret = 1;
+	char *oem_info;
 
 	if ((!subsys || !strcmp(subsys, "i2c")) &&
 	    sscanf(dev_name, "%hd-%x", &entry->chip.bus.nr,
@@ -669,9 +681,16 @@ static int classify_device(const char *dev_name,
 		entry->chip.bus.nr = 0;
 	} else if (subsys && !strcmp(subsys, "acpi")) {
 		entry->chip.bus.type = SENSORS_BUS_TYPE_ACPI;
-		/* For now we assume that acpi devices are unique */
+		/* For ACPI power meter devices, use oem_info */
 		entry->chip.bus.nr = 0;
 		entry->chip.addr = 0;
+		if (!strcmp(entry->chip.prefix, SENSORS_POWER_METER_NAME)) {
+			oem_info = sysfs_read_attr(entry->chip.path, "power1_oem_info");
+			if (oem_info) {
+				replace_space_underscore(oem_info);
+				entry->chip.oem_info = oem_info;
+			}
+		}
 	} else
 	if (subsys && !strcmp(subsys, "hid") &&
 	    sscanf(dev_name, "%x:%x:%x.%x", &bus, &vendor, &product, &id) == 4) {
@@ -770,6 +789,9 @@ static int sensors_read_one_sysfs_chip(const char *dev_path,
 	if (!entry.chip.path)
 		sensors_fatal_error(__func__, "Out of memory");
 
+	/* oem_info will set in classify_device */
+	entry.chip.oem_info = NULL;
+
 	if (dev_path == NULL) {
 		virtual = 1;
 	} else {
@@ -804,6 +826,7 @@ static int sensors_read_one_sysfs_chip(const char *dev_path,
 exit_free:
 	free(entry.chip.prefix);
 	free(entry.chip.path);
+	free(entry.chip.oem_info);
 	return ret;
 }
 


### PR DESCRIPTION
Dear lm-sensors development team,

This commit improves ACPI power meter device display.

Currently, the ACPI power meter device display is fixed as "power_meter-acpi-0".
Therefore, machines with multiple ACPI power meter devices cannot distinguish between these devices.

To address this, I modified the display to include information from power1_oem_info.

On Nvidia Grace machines, the display changes as follows:
before:
    power_meter-acpi-0
after:
    power_meter-acpi-Grace_Power_Socket_0

Please review and merge these patches

Best regards,
Kazuhiro Abe