### PR TITLE
[FIX] ISA sysfs address parsing

### DIFF
--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -663,7 +663,7 @@ static int classify_device(const char *dev_name,
 	if ((!subsys || !strcmp(subsys, "platform") ||
 			!strcmp(subsys, "of_platform"))) {
 		/* must be new ISA (platform driver) */
-		if (sscanf(dev_name, "%*[a-zA-Z0-9_]%*1[.:]%d", &entry->chip.addr) != 1)
+		if (sscanf(dev_name, "%*[a-zA-Z0-9_\-]%*1[.:]%d", &entry->chip.addr) != 1)
 			entry->chip.addr = 0;
 		entry->chip.bus.type = SENSORS_BUS_TYPE_ISA;
 		entry->chip.bus.nr = 0;


### PR DESCRIPTION
The ISA sensor chip address of a sensor is obtained by parsing the hwmon `/sysfs` device path. The regular expression extracting the device address will fail if the device name contains dashes and sets the address to 0. If multiple instances of the same board are plugged into the same system, cards can no longer be distinguished, because their addresses will be set to 0 incorrectly.

This fix changes the address-parsing regular expression to recognize device names with dashes.