### PR TITLE
Update B450-Gaming-ITX-ac.conf

### DIFF
--- a/configs/ASRock/B450-Gaming-ITX-ac.conf
+++ b/configs/ASRock/B450-Gaming-ITX-ac.conf
@@ -1,5 +1,10 @@
 # ASRock B450 Gaming-ITX/ac
 # manufacturing date July 2019 (came with Zen2-aware BIOS)
+
+# dmi: Manufacturer: ASRock
+# dmi: Product Name: B450 Gaming-ITX/ac
+# dmi: BIOS Information - Version: P10.41
+# cpu: AMD Ryzen 7 5700X 8-Core Processor
 # board does have connectors for buzzer and 3 fans (2 case + 1 CPU)
 # board does not have a connector for intrusion detection
 # dmesg: "nct6775: Found NCT6792D or compatible chip at 0x2e:0x290"
@@ -22,26 +27,38 @@ chip "nct6792-*"
    set     in2_max 3.30 * 1.10
 
    label   in3     "+3.3V"
-   set     in3_min 3.30 * 0.90
-   set     in3_max 3.30 * 1.10
+   set     in3_min 3.30 * 0.95 # ATX v2.2 spec
+   set     in3_max 3.30 * 1.05 # ATX v2.2 spec
 
    label   in7     "3VSB"
-   set     in7_min 3.30 * 0.90
-   set     in7_max 3.30 * 1.10
+   set     in7_min 3.30 * 0.95 # assume ATX ±5% is enough
+   set     in7_max 3.30 * 1.05 # assume ATX ±5% is enough
 
    label   in8 "VBAT"
-   set     in8_min 3.00 * 0.90
-   set     in8_max 3.30 * 1.10
+   set     in8_min 2.0  # from MS-7B89-B450M-MORTAR.conf
+   set     in8_max 3.4  # from MS-7B89-B450M-MORTAR.conf
 
-   label   in9 "+12V"
-   compute in9 @*(53/8), @/(53/8)
-   set     in9_min 12 * 0.90
-   set     in9_max 12 * 1.10
+   label   in9 "+1.8 Voltage" # BIOS setting OC Tweaker --> External Voltage Settings and Load-Line Calibration --> +1.8 Voltage
+   set     in9_min 1.7 * 0.95 # lower limit of +1.8 voltage in BIOS: +1.7V
+   set     in9_max 2.1 * 1.05 # upper limit of +1.8 voltage in BIOS: +2.1V
+
+   label   in12 "+12V"
+   # values from nuvoton nct6779D datasheet
+   # Section 8.5 Analog Inputs (Page 54,55)
+   # #       Vs     R1,Rin   R2,Rf    Vin
+   # in12  +12.0    56       10     ~+1.84
+   compute in12 @*((56/10)+1), @/((56/10)+1)
+   set     in12_min 12 * 0.95 # ATX v2.2 spec
+   set     in12_max 12 * 1.05 # ATX v2.2 spec
 
    label   in13     "+5V"
-   compute in13 @*(24/8), @/(24/8)
-   set     in13_min 5 * 0.90
-   set     in13_max 5 * 1.10
+   # values from nuvoton nct6779D datasheet
+   # Section 8.5 Analog Inputs (Page 54,55)
+   # #       Vs     R1,Rin   R2,Rf    Vin
+   # in13  +5.0     20       10     ~+1.67
+   compute in13 @*((20/10)+1), @/((20/10)+1)
+   set     in13_min 5 * 0.95 # ATX v2.2 spec
+   set     in13_max 5 * 1.05 # ATX v2.2 spec
 
    # these are all zero
    ignore  in1
@@ -53,7 +70,6 @@ chip "nct6792-*"
    # these have non-zero input, but are unknown
    ignore  in10
    ignore  in11
-   ignore  in12
 
    # temperatures
    # not sure about temp2 and temp3 


### PR DESCRIPTION
Corrected in9 = +1.8V voltage that can be set by the user in BIOS 

Added in12 = +12V

Updated calculations for 12V and 5V from Nuvoton datasheet - now the values fit to what the BIOS reports.

Updated limits.