### PR TITLE
Add decimal places to frequency value when multiplier is applied

### DIFF
--- a/prog/sensors/chips.c
+++ b/prog/sensors/chips.c
@@ -963,9 +963,12 @@ static void print_chip_freq(const sensors_chip_name *name,
 				    SENSORS_SUBFEATURE_FREQ_INPUT);
 	if (sf && get_input_value(name, sf, &val) == 0) {
 		scale_value(&val, &unit);
-		printf("%4.0f %sHz%*s", val, unit, 2 - (int)strlen(unit), "");
+		if(strlen(unit))
+			printf("%6.2f %sHz%*s", val, unit, 2 - (int)strlen(unit), "");
+		else
+			printf("%4.0f %sHz%*s  ", val, unit, 2 - (int)strlen(unit), "");
 	} else {
-		printf("     N/A  ");
+		printf("     N/A    ");
 	}
 
 	printf("\n");


### PR DESCRIPTION
Frequency is printed as %4.0f which is fine when no multiplier is applied (eg. 50 Hz) but not great when multiplier is used (1 GHz displayed even when the value would round to 1.1 if enough decimal places were available).

Change to %6.2f as most other values when multiplier is applied.

Fixes: #552