### PR TITLE
Add config for MSI B450I GAMING PLUS AC (MS-7A40)

### DIFF
--- a/configs/MSI/MS-7A40-B450I-GAMING-PLUS-AC.conf
+++ b/configs/MSI/MS-7A40-B450I-GAMING-PLUS-AC.conf
@@ -1,0 +1,211 @@
+# lm-sensors configuration for MSI B450I GAMING PLUS AC / MS-7A40
+#
+# Manufacturer: Micro-Star International (MSI)
+# Product Name: MSI B450I GAMING PLUS AC
+# Code Name: MS-7A40
+# Board Revision: 2.0 (confirmed by dmidecode)
+# BIOS Version: 7A40vA0 2018-06-28
+# Super I/O: Nuvoton NCT6795D-M
+#
+# Original configuration assembled by Marc from the sensor channels exposed
+# by lm-sensors, available MSI configurations and plausibility checks. At that
+# time no board-specific schematic was available.
+#
+# Mapping verified and completed in 2026 with GPT / OpenAI using:
+# - MSI MS-7A40 Rev.2.0 schematic, sheet 33 "SIO NCT6795" (document rev 20)
+# - Linux nct6775 driver channel/input ordering
+# - live sensor values from this physical MS-7A40 Rev.2.0 board
+#
+# Voltage dividers and multiplexed voltage/temperature inputs below are derived
+# from the Rev.2.0 schematic. Live readings were then used as a sanity check,
+# not as the primary basis for assigning board functions.
+#
+# Channels without a reliably documented board function are deliberately
+# ignored rather than assigned a guessed label.
+#
+# Recommended drivers: k10temp, nct6795
+
+
+chip "nvme-pci-*"
+
+	# No usable temperature value is exposed here on this system.
+	ignore temp1
+	ignore temp2
+	ignore temp3
+	ignore temp6
+
+
+chip "nct6795-isa-*"
+
+	### SPANNUNGEN ###
+	#
+	# Linux NCT6795/NCT6779 voltage-input order used to translate the
+	# schematic's NCT6795 pin/net names to lm-sensors in0..in14:
+	#
+	# in0  = CPUVC
+	# in1  = VIN1
+	# in2  = AVSB
+	# in3  = 3VCC
+	# in4  = VIN0
+	# in5  = VIN8
+	# in6  = VIN4 / AUXTIN0
+	# in7  = 3VSB
+	# in8  = VBAT
+	# in9  = VTT
+	# in10 = VIN5 / AUXTIN1
+	# in11 = VIN6 / AUXTIN2
+	# in12 = VIN2
+	# in13 = VIN3 / VDIMM
+	# in14 = VIN7 / AUXTIN3
+	#
+	# The assignments and divider values below are taken from MS-7A40
+	# Rev.2.0 sheet 33 and checked against the live readings of this board.
+
+	# CPUVC/CPUVCORE: VCORE -> R483 10K -> CPUVCORE.
+	# R484 (10K to GND) is marked X = not populated, therefore no divider.
+	label in0 "CPU Vcore"
+
+	# VIN1: VCC5 -> R479 12K -> VIN1; R482 3K -> GND.
+	# Divider factor = (12K + 3K) / 3K = 5.
+	label in1 "System +5V"
+	compute in1 @ * 5, @ / 5
+
+	# AVSB: NCT6795 analog standby supply on the 3.3 V domain.
+	label in2 "AVSB +3.3V"
+
+	# 3VCC: NCT6795 3.3 V supply input.
+	label in3 "System +3.3V"
+
+	# VIN0: +12V -> R46 220K -> VIN0; R45 20K -> GND.
+	# Divider factor = (220K + 20K) / 20K = 12.
+	label in4 "System +12V"
+	compute in4 @ * 12, @ / 12
+
+	# VIN8: no board net identified on Rev.2.0 sheet 33.
+	label in5 "UNBEKANNT (VIN8)"
+	ignore in5
+
+	# VIN4 shares pin 111 with AUXTIN0 and is used by CPUMOSTIN
+	# on this board. Treat it as a temperature channel, not a voltage.
+	ignore in6
+
+	# 3VSB: NCT6795 3.3 V standby supply.
+	label in7 "+3V Standby"
+
+	# VBAT: RTC/CMOS battery input.
+	label in8 "CMOS Bat. +3V"
+	set in8_min  3.0 * 0.90
+	set in8_max  3.3 * 1.10
+
+	# VTT pin 119 is wired directly to CPU_1P8 on Rev.2.0 sheet 33.
+	label in9 "CPU +1.8V"
+
+	# VIN5 shares pin 114 with AUXTIN1 and is wired:
+	# CPU_VDDP -> R508 10K -> VIN5. No divider to GND is fitted.
+	label in10 "CPU VDDP"
+
+	# VIN6 shares pin 115 with AUXTIN2 and is used by PROMTIN
+	# (Promontory/B450 temperature). Do not expose it as voltage.
+	ignore in11
+
+	# VIN2: VCCP_NB -> R504 10K -> VIN2.
+	# R505 (10K to GND) is marked X = not populated, so no divider.
+	# VCCP_NB is exposed as "CPU NB/SOC" for a descriptive user-facing name.
+	label in12 "CPU NB/SOC"
+
+	# VIN3/VDIMM: VCC_DDR -> R499 10K -> VDIMM; R485 10K -> GND.
+	# Divider factor = (10K + 10K) / 10K = 2.
+	label in13 "VDRAM"
+	compute in13 @ * 2, @ / 2
+
+	# VIN7 shares pin 116 with AUXTIN3 and is wired to ATX_5VSB:
+	# ATX_5VSB -> R489 7.68K -> VIN7; R491 3.3K -> GND.
+	# Divider factor = (7.68K + 3.3K) / 3.3K = 3.3272727...
+	label in14 "+5V Standby"
+	compute in14 @ * (7.68 + 3.3) / 3.3, @ * 3.3 / (7.68 + 3.3)
+
+
+	### LUEFTER ###
+	ignore fan1
+
+	label fan2 "CPU Fan"
+	label fan3 "Case Fan"
+
+	ignore fan4
+	ignore fan5
+	ignore fan6
+	ignore fan7
+	ignore fan8
+	ignore fan9
+	ignore fan10
+
+
+	### TEMPERATUREN ###
+	#
+	# MS-7A40 Rev.2.0 sheet 33 identifies the physical thermistor nets:
+	#
+	# SYSTIN     = "For System Close to SIO"
+	# CPUTIN     = "For CPU Under Socket"
+	# CPUMOSTIN  = "Close to CPU MOS"
+	# PROMTIN    = "Place to under Promontory"
+	#
+	# Pin multiplexing on the NCT6795:
+	# CPUMOSTIN -> pin 111 -> AUXTIN0/VIN4
+	# PROMTIN   -> pin 115 -> AUXTIN2/VIN6
+	#
+	# Linux NCT6795 temperature-channel ordering relevant to these pins:
+	# temp1 = SYSTIN
+	# temp2 = CPUTIN
+	# temp3 = AUXTIN0
+	# temp4 = AUXTIN1
+	# temp5 = AUXTIN2
+	# temp6 = AUXTIN3
+
+	label temp1 "System"
+	label temp2 "CPU Socket"
+	label temp3 "VRM MOS"
+
+	# AUXTIN1 is used as VIN5 for CPU_VDDP on this board.
+	ignore temp4
+
+	# AUXTIN2 is physically PROMTIN under the AMD Promontory/B450 chipset.
+	label temp5 "B450 Chipset"
+
+	# AUXTIN3 is used as VIN7 for ATX_5VSB on this board.
+	ignore temp6
+
+	# No reliable MS-7A40 Rev.2.0 board function is documented here for the
+	# remaining temperature channels, so they are intentionally suppressed.
+	ignore temp7
+	ignore temp8
+	ignore temp9
+	ignore temp10
+	ignore temp11
+	ignore temp12
+	ignore temp13
+
+	label intrusion0 "Intrusion #0"
+	label intrusion1 "Intrusion #1"
+	label beep_enable "Beep enable"
+
+
+chip "k10temp-pci-*"
+
+	### TEMPERATUREN ###
+	label temp1 "CPU Tctl"
+
+
+chip "amdgpu-pci-*"
+
+	### TEMPERATUREN ###
+	label temp1 "GPU"
+
+	# No useful voltage readings are exposed by this hwmon device here.
+	ignore "in0"
+	ignore "in1"
+
+
+chip "iwlwifi_1-virtual-*"
+
+	# No useful temperature reading is exposed by this hwmon device here.
+	ignore "temp1"


### PR DESCRIPTION
Adds an lm-sensors configuration for the MSI B450I GAMING PLUS AC (MS-7A40).

Tested on:

MSI B450I GAMING PLUS AC (MS-7A40)
Board revision 2.0
Nuvoton NCT6795D-M Super I/O

The sensor mappings and voltage divider calculations were verified against the MS-7A40 Rev. 2.0 schematic and validated against live sensor readings from the board.

The configuration provides labels and scaling for the available voltage, temperature and fan inputs. Channels which could not be reliably identified are intentionally not assigned speculative labels.